### PR TITLE
Dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rox",
-  "version": "2025.12.0-beta.3",
+  "version": "2025.12.0-beta.4",
   "private": true,
   "description": "Lightweight ActivityPub server & client with Misskey API compatibility",
   "workspaces": [

--- a/packages/frontend/src/lib/auth/AuthManager.ts
+++ b/packages/frontend/src/lib/auth/AuthManager.ts
@@ -1,5 +1,6 @@
 import type { IAuthProvider, AuthMethod, AuthResult } from "./types";
 import { PasswordAuthProvider } from "./providers/PasswordAuthProvider";
+import { PasskeyProvider } from "./providers/PasskeyProvider";
 
 /**
  * Central authentication manager
@@ -11,6 +12,19 @@ export class AuthManager {
   constructor() {
     // Register default password provider
     this.registerProvider(new PasswordAuthProvider());
+
+    // Register passkey provider with dynamic rpId from current hostname
+    // Only register if we're in a browser environment
+    if (typeof window !== "undefined") {
+      this.registerProvider(
+        new PasskeyProvider({
+          rpId: window.location.hostname,
+          rpName: "Rox",
+          userVerification: "preferred",
+          attestation: "none",
+        }),
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
Register PasskeyProvider in AuthManager by default when in browser
environment. The rpId is dynamically set from window.location.hostname.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>