### PR TITLE
Release v2025.12.0-rc.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rox",
-  "version": "2025.12.0-rc.2",
+  "version": "2025.12.0-rc.3",
   "devDependencies": {
     "@playwright/test": "^1.57.0",
     "@types/bun": "latest",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hono_rox",
-  "version": "0.1.0-rc.2",
+  "version": "0.1.0-rc.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waku_rox",
-  "version": "0.1.0-rc.2",
+  "version": "0.1.0-rc.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shared",
-  "version": "0.1.0-rc.2",
+  "version": "0.1.0-rc.3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
## Summary

Bumps version to 2025.12.0-rc.3.

This release includes all changes from PR #29:
- 🔐 OAuth 2.0 authentication (GitHub, Google, Discord, Mastodon)
- 👥 Admin user management (deletion, remote users, MFM rendering)
- 📊 Admin job queue dashboard
- 🎨 Timeline card entrance animation
- 🌐 Japanese translations for admin pages

## Test plan
- [x] CI passes
- [x] Version numbers updated in all package.json files

🤖 Generated with [Claude Code](https://claude.com/claude-code)