### PR TITLE
docs: clarify release.yml as manual release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,43 @@
-name: Release
+name: Manual Release
+
+# Manual release workflow for:
+# - Hotfix releases (bypassing normal dev -> main flow)
+# - Re-creating failed releases
+# - Creating releases from manually pushed tags
+#
+# For normal releases, use auto-tag.yml (triggered by version bump in package.json)
 
 on:
+  # Trigger on manually pushed tags (not created by auto-tag workflow)
   push:
     tags:
       - "v*"
+  # Manual trigger from GitHub Actions UI
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g., v2025.12.0-rc.8)"
+        required: true
+        type: string
+      skip_ci:
+        description: "Skip CI checks (use for re-releases only)"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
 
 jobs:
-  # 1. Run CI workflow first
+  # 1. Run CI workflow first (unless skipped)
   call-ci:
+    if: ${{ github.event_name == 'push' || !inputs.skip_ci }}
     uses: ./.github/workflows/ci.yml
-    # If CI uses secrets, uncomment below
-    # secrets: inherit
 
   # 2. Create release after CI passes
   create-release:
     needs: call-ci
+    if: ${{ always() && (needs.call-ci.result == 'success' || needs.call-ci.result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -27,17 +47,32 @@ jobs:
 
       - name: Get version from tag
         id: version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+          echo "Processing tag: $TAG"
+
+      - name: Checkout tag (for workflow_dispatch)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          git fetch --tags
+          git checkout "${{ steps.version.outputs.tag }}"
 
       - name: Determine Release Type
         id: check
         run: |
+          TAG="${{ steps.version.outputs.tag }}"
           git fetch origin main dev 2>/dev/null || true
 
           # Check if this is a prerelease based on tag name
-          if [[ "${{ github.ref_name }}" == *"-alpha"* ]] || \
-             [[ "${{ github.ref_name }}" == *"-beta"* ]] || \
-             [[ "${{ github.ref_name }}" == *"-rc"* ]]; then
+          if [[ "$TAG" == *"-alpha"* ]] || \
+             [[ "$TAG" == *"-beta"* ]] || \
+             [[ "$TAG" == *"-rc"* ]]; then
             echo "Pre-release tag detected."
             echo "is_prerelease=true" >> $GITHUB_OUTPUT
           # Check if commit is on main branch
@@ -81,7 +116,7 @@ jobs:
         id: changelog
         run: |
           PREV_TAG="${{ steps.prev_tag.outputs.prev_tag }}"
-          CURRENT_TAG="${{ github.ref_name }}"
+          CURRENT_TAG="${{ steps.version.outputs.tag }}"
 
           echo "Generating changelog from $PREV_TAG to $CURRENT_TAG"
 
@@ -174,6 +209,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.version.outputs.tag }}
           name: "Rox ${{ steps.version.outputs.version }}"
           body_path: CHANGELOG.md
           prerelease: ${{ steps.check.outputs.is_prerelease }}


### PR DESCRIPTION
## Summary / 概要

Clarify the role of `release.yml` as a manual release workflow.

`release.yml`の役割を手動リリース用ワークフローとして明確化。

## Changes / 変更内容

- Renamed workflow to "Manual Release"
- Added `workflow_dispatch` trigger for manual execution from GitHub UI
- Added `skip_ci` option for re-releases (when CI already passed)
- Added `tag` input for specifying which tag to release
- Documented use cases in workflow comments

## Use Cases / 用途

1. **Hotfix releases** - Bypass normal dev -> main flow
2. **Re-creating failed releases** - Skip CI if already verified
3. **Manual tag pushes** - Releases from tags not created by auto-tag

## Workflow Roles / ワークフローの役割

| Workflow | Trigger | Purpose |
|----------|---------|---------|
| `auto-tag.yml` | package.json version change on main | Normal releases |
| `release.yml` | Manual trigger / manual tag push | Hotfixes, re-releases |

🤖 Generated with [Claude Code](https://claude.com/claude-code)