### PR TITLE
fix(ap): include file attachments in outbound ActivityPub delivery

### DIFF
--- a/packages/backend/src/di/container.ts
+++ b/packages/backend/src/di/container.ts
@@ -158,6 +158,7 @@ export function createContainer(): AppContainer {
     activityDeliveryQueue,
     repositories.instanceBlockRepository,
     repositories.customEmojiRepository,
+    repositories.driveFileRepository,
   );
 
   // Role and Instance Settings Services

--- a/packages/backend/src/services/ap/delivery/ActivityBuilder.ts
+++ b/packages/backend/src/services/ap/delivery/ActivityBuilder.ts
@@ -49,6 +49,16 @@ export interface MentionTag {
 }
 
 /**
+ * ActivityPub attachment object structure (Document type)
+ */
+export interface AttachmentObject {
+  type: "Document";
+  mediaType: string;
+  url: string;
+  name?: string;
+}
+
+/**
  * ActivityPub Note object structure
  */
 export interface NoteObject {
@@ -60,7 +70,7 @@ export interface NoteObject {
   to: string[];
   cc: string[];
   inReplyTo?: string | null;
-  attachment?: unknown[];
+  attachment?: AttachmentObject[];
   tag?: (EmojiTag | MentionTag)[];
   sensitive?: boolean;
   summary?: string | null;
@@ -194,8 +204,14 @@ export class ActivityBuilder {
    * @param note - The note to create an activity for
    * @param author - The author of the note
    * @param emojiTags - Optional array of custom emoji tags to include
+   * @param attachments - Optional array of file attachments to include
    */
-  createNote(note: Note, author: User, emojiTags?: EmojiTag[]): Activity {
+  createNote(
+    note: Note,
+    author: User,
+    emojiTags?: EmojiTag[],
+    attachments?: AttachmentObject[],
+  ): Activity {
     const actorUri = this.actorUri(author.username);
     const followersUri = this.followersUri(author.username);
     const published = note.createdAt.toISOString();
@@ -224,6 +240,11 @@ export class ActivityBuilder {
     // Add emoji tags if provided
     if (emojiTags && emojiTags.length > 0) {
       noteObject.tag = emojiTags;
+    }
+
+    // Add file attachments if provided
+    if (attachments && attachments.length > 0) {
+      noteObject.attachment = attachments;
     }
 
     // Add optional fields


### PR DESCRIPTION
## Summary

When a local user creates a note with images, the ActivityPub Create activity was **not including the file attachments**. Remote servers (Misskey, Mastodon, etc.) could only see the images if they explicitly fetched the note via HTTP GET, but not when receiving the Create activity via inbox delivery.

## Root Cause

- `ActivityBuilder.createNote()` had an `attachment` field in the NoteObject interface but never populated it
- `ActivityPubDeliveryService.deliverCreateNote()` didn't resolve file metadata from `fileIds`

## Changes

- **ActivityBuilder.ts**:
  - Add `AttachmentObject` interface for typed attachment objects
  - Update `createNote()` to accept optional `attachments` parameter
  
- **ActivityPubDeliveryService.ts**:
  - Add `driveFileRepository` dependency for file lookup
  - Add `buildAttachments()` method to convert fileIds to ActivityPub Document format
  - Call `buildAttachments()` in `deliverCreateNote()` and pass to `createNote()`

- **container.ts**:
  - Inject `driveFileRepository` into `ActivityPubDeliveryService`

## Attachment Format (ActivityPub/Mastodon/Misskey compatible)

```json
{
  "attachment": [
    {
      "type": "Document",
      "mediaType": "image/png",
      "url": "https://example.com/files/image.png",
      "name": "filename.png"
    }
  ]
}
```

## Test Plan

- [x] TypeScript type check passes
- [x] All 844 unit tests pass
- [ ] Manual verification: create note with image, check if remote server receives attachment

Relates to #47