### PR TITLE
fix(images): increase thumbnail size for better timeline quality

### DIFF
--- a/packages/backend/src/services/ImageProcessor.ts
+++ b/packages/backend/src/services/ImageProcessor.ts
@@ -43,9 +43,9 @@ export interface ProcessOptions {
   maxWidth?: number;
   /** Maximum height for WebP conversion (preserves aspect ratio) */
   maxHeight?: number;
-  /** Thumbnail width (default: 400) */
+  /** Thumbnail width (default: 800) */
   thumbnailWidth?: number;
-  /** Thumbnail height (default: 400) */
+  /** Thumbnail height (default: 800) */
   thumbnailHeight?: number;
   /** Generate blurhash (default: true) */
   generateBlurhash?: boolean;
@@ -58,8 +58,8 @@ const DEFAULT_OPTIONS: Required<ProcessOptions> = {
   webpQuality: 80,
   maxWidth: 2048,
   maxHeight: 2048,
-  thumbnailWidth: 400,
-  thumbnailHeight: 400,
+  thumbnailWidth: 800,
+  thumbnailHeight: 800,
   generateBlurhash: true,
 };
 


### PR DESCRIPTION
## Summary

- Increase default thumbnail dimensions from 400x400 to 800x800 pixels
- Improves image quality on timeline views where thumbnails are displayed in larger grid cells

Closes #52

## Root Cause

The timeline displays images using `file.thumbnailUrl`, which was generated at 400x400 pixels. When displayed in the grid layout, these thumbnails were being upscaled, resulting in blurry/pixelated images. The full-resolution image only appeared when clicking to expand in the modal.

## Solution

Increase the default thumbnail size to 800x800 pixels in `ImageProcessor.ts`. This provides a good balance between:
- **Quality**: Thumbnails are sharp on most displays
- **Performance**: Still significantly smaller than full-resolution images
- **Storage**: Reasonable file sizes for thumbnails

## Test Plan

- [ ] Upload a new image and create a note
- [ ] Verify image appears sharp in timeline (not blurry/pixelated)
- [ ] Verify modal still shows full resolution image
- [ ] Compare with existing images (existing thumbnails will remain at old size until re-uploaded)

## Note

This fix only affects **newly uploaded images**. Existing images will retain their 400x400 thumbnails until re-uploaded.