### PR TITLE
feat(lists): add user list management feature

### DIFF
--- a/packages/backend/drizzle/postgres/0010_overjoyed_living_mummy.sql
+++ b/packages/backend/drizzle/postgres/0010_overjoyed_living_mummy.sql
@@ -1,0 +1,40 @@
+CREATE TABLE IF NOT EXISTS "user_list_members" (
+	"id" text PRIMARY KEY NOT NULL,
+	"list_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"with_replies" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "user_lists" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"name" text NOT NULL,
+	"is_public" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "user_list_members" ADD CONSTRAINT "user_list_members_list_id_user_lists_id_fk" FOREIGN KEY ("list_id") REFERENCES "public"."user_lists"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "user_list_members" ADD CONSTRAINT "user_list_members_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "user_lists" ADD CONSTRAINT "user_lists_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "user_list_member_list_user_idx" ON "user_list_members" USING btree ("list_id","user_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "user_list_member_list_idx" ON "user_list_members" USING btree ("list_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "user_list_member_user_idx" ON "user_list_members" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "user_list_user_idx" ON "user_lists" USING btree ("user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "user_list_user_name_idx" ON "user_lists" USING btree ("user_id","name");

--- a/packages/backend/drizzle/postgres/meta/0010_snapshot.json
+++ b/packages/backend/drizzle/postgres/meta/0010_snapshot.json
@@ -1,0 +1,4279 @@
+{
+  "id": "8ef810f7-8642-4490-9013-c27b881c9698",
+  "prevId": "a396ce0b-eee7-4fbd-96d2-c59a9da22b5a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.blocked_usernames": {
+      "name": "blocked_usernames",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_regex": {
+          "name": "is_regex",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocked_username_pattern_idx": {
+          "name": "blocked_username_pattern_idx",
+          "columns": [
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocked_usernames_created_by_id_users_id_fk": {
+          "name": "blocked_usernames_created_by_id_users_id_fk",
+          "tableFrom": "blocked_usernames",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_messages": {
+      "name": "contact_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_type": {
+          "name": "sender_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "attachment_ids": {
+          "name": "attachment_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_message_thread_id_idx": {
+          "name": "contact_message_thread_id_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_message_sender_id_idx": {
+          "name": "contact_message_sender_id_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_message_created_at_idx": {
+          "name": "contact_message_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_messages_thread_id_contact_threads_id_fk": {
+          "name": "contact_messages_thread_id_contact_threads_id_fk",
+          "tableFrom": "contact_messages",
+          "tableTo": "contact_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contact_messages_sender_id_users_id_fk": {
+          "name": "contact_messages_sender_id_users_id_fk",
+          "tableFrom": "contact_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_threads": {
+      "name": "contact_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_to_id": {
+          "name": "assigned_to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "internal_notes": {
+          "name": "internal_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contact_thread_user_id_idx": {
+          "name": "contact_thread_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_thread_status_idx": {
+          "name": "contact_thread_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_thread_category_idx": {
+          "name": "contact_thread_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_thread_created_at_idx": {
+          "name": "contact_thread_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_thread_assigned_to_idx": {
+          "name": "contact_thread_assigned_to_idx",
+          "columns": [
+            {
+              "expression": "assigned_to_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_threads_user_id_users_id_fk": {
+          "name": "contact_threads_user_id_users_id_fk",
+          "tableFrom": "contact_threads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_threads_assigned_to_id_users_id_fk": {
+          "name": "contact_threads_assigned_to_id_users_id_fk",
+          "tableFrom": "contact_threads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_to_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_emojis": {
+      "name": "custom_emojis",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_url": {
+          "name": "public_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_sensitive": {
+          "name": "is_sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "local_only": {
+          "name": "local_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "emoji_name_host_idx": {
+          "name": "emoji_name_host_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emoji_host_idx": {
+          "name": "emoji_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emoji_category_idx": {
+          "name": "emoji_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_files": {
+      "name": "drive_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "md5": {
+          "name": "md5",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blurhash": {
+          "name": "blurhash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_sensitive": {
+          "name": "is_sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "file_user_id_idx": {
+          "name": "file_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_folder_id_idx": {
+          "name": "file_folder_id_idx",
+          "columns": [
+            {
+              "expression": "folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_md5_idx": {
+          "name": "file_md5_idx",
+          "columns": [
+            {
+              "expression": "md5",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_source_idx": {
+          "name": "file_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_files_user_id_users_id_fk": {
+          "name": "drive_files_user_id_users_id_fk",
+          "tableFrom": "drive_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_files_folder_id_drive_folders_id_fk": {
+          "name": "drive_files_folder_id_drive_folders_id_fk",
+          "tableFrom": "drive_files",
+          "tableTo": "drive_folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_folders": {
+      "name": "drive_folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "folder_user_id_idx": {
+          "name": "folder_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "folder_parent_id_idx": {
+          "name": "folder_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_folders_user_id_users_id_fk": {
+          "name": "drive_folders_user_id_users_id_fk",
+          "tableFrom": "drive_folders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follows": {
+      "name": "follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "followee_id": {
+          "name": "followee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "follow_follower_followee_idx": {
+          "name": "follow_follower_followee_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "followee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "follow_follower_idx": {
+          "name": "follow_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "follow_followee_idx": {
+          "name": "follow_followee_idx",
+          "columns": [
+            {
+              "expression": "followee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "follows_follower_id_users_id_fk": {
+          "name": "follows_follower_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follows_followee_id_users_id_fk": {
+          "name": "follows_followee_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "followee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_blocks": {
+      "name": "instance_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_by_id": {
+          "name": "blocked_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "instance_block_host_idx": {
+          "name": "instance_block_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instance_blocks_blocked_by_id_users_id_fk": {
+          "name": "instance_blocks_blocked_by_id_users_id_fk",
+          "tableFrom": "instance_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocked_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "instance_blocks_host_unique": {
+          "name": "instance_blocks_host_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "host"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_settings": {
+      "name": "instance_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by_id": {
+          "name": "updated_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "instance_settings_updated_by_id_users_id_fk": {
+          "name": "instance_settings_updated_by_id_users_id_fk",
+          "tableFrom": "instance_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation_codes": {
+      "name": "invitation_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_by_id": {
+          "name": "used_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_code_idx": {
+          "name": "invitation_code_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_created_by_idx": {
+          "name": "invitation_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_codes_created_by_id_users_id_fk": {
+          "name": "invitation_codes_created_by_id_users_id_fk",
+          "tableFrom": "invitation_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_codes_used_by_id_users_id_fk": {
+          "name": "invitation_codes_used_by_id_users_id_fk",
+          "tableFrom": "invitation_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "used_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_codes_code_unique": {
+          "name": "invitation_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moderation_audit_logs": {
+      "name": "moderation_audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "moderator_id": {
+          "name": "moderator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_moderator_idx": {
+          "name": "audit_moderator_idx",
+          "columns": [
+            {
+              "expression": "moderator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_action_idx": {
+          "name": "audit_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_target_type_idx": {
+          "name": "audit_target_type_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_target_id_idx": {
+          "name": "audit_target_id_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_created_at_idx": {
+          "name": "audit_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "moderation_audit_logs_moderator_id_users_id_fk": {
+          "name": "moderation_audit_logs_moderator_id_users_id_fk",
+          "tableFrom": "moderation_audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "moderator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notes": {
+      "name": "notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cw": {
+          "name": "cw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "local_only": {
+          "name": "local_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reply_id": {
+          "name": "reply_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "renote_id": {
+          "name": "renote_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_ids": {
+          "name": "file_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "mentions": {
+          "name": "mentions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "emojis": {
+          "name": "emojis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replies_count": {
+          "name": "replies_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "renote_count": {
+          "name": "renote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by_id": {
+          "name": "deleted_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletion_reason": {
+          "name": "deletion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_user_id_idx": {
+          "name": "note_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_created_at_idx": {
+          "name": "note_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_reply_id_idx": {
+          "name": "note_reply_id_idx",
+          "columns": [
+            {
+              "expression": "reply_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_renote_id_idx": {
+          "name": "note_renote_id_idx",
+          "columns": [
+            {
+              "expression": "renote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_uri_idx": {
+          "name": "note_uri_idx",
+          "columns": [
+            {
+              "expression": "uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_user_timeline_idx": {
+          "name": "note_user_timeline_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_local_timeline_idx": {
+          "name": "note_local_timeline_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_only",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_is_deleted_idx": {
+          "name": "note_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notes_user_id_users_id_fk": {
+          "name": "notes_user_id_users_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notes_deleted_by_id_users_id_fk": {
+          "name": "notes_deleted_by_id_users_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notifier_id": {
+          "name": "notifier_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warning_id": {
+          "name": "warning_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_id_idx": {
+          "name": "notification_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_user_id_is_read_idx": {
+          "name": "notification_user_id_is_read_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_user_id_created_at_idx": {
+          "name": "notification_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_type_idx": {
+          "name": "notification_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_notifier_id_users_id_fk": {
+          "name": "notifications_notifier_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "notifier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_note_id_notes_id_fk": {
+          "name": "notifications_note_id_notes_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_warning_id_user_warnings_id_fk": {
+          "name": "notifications_warning_id_user_warnings_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user_warnings",
+          "columnsFrom": [
+            "warning_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_username": {
+          "name": "provider_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_email": {
+          "name": "provider_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_user_provider_idx": {
+          "name": "oauth_user_provider_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_provider_account_idx": {
+          "name": "oauth_provider_account_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_user_id_idx": {
+          "name": "oauth_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey_challenges": {
+      "name": "passkey_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "challenge": {
+          "name": "challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "passkey_challenge_idx": {
+          "name": "passkey_challenge_idx",
+          "columns": [
+            {
+              "expression": "challenge",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_challenge_expires_idx": {
+          "name": "passkey_challenge_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_challenges_user_id_users_id_fk": {
+          "name": "passkey_challenges_user_id_users_id_fk",
+          "tableFrom": "passkey_challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "passkey_challenges_challenge_unique": {
+          "name": "passkey_challenges_challenge_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "challenge"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey_credentials": {
+      "name": "passkey_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_credential_id_idx": {
+          "name": "passkey_credential_id_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_user_id_idx": {
+          "name": "passkey_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_credentials_user_id_users_id_fk": {
+          "name": "passkey_credentials_user_id_users_id_fk",
+          "tableFrom": "passkey_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "passkey_credentials_credential_id_unique": {
+          "name": "passkey_credentials_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_subscription_user_id_idx": {
+          "name": "push_subscription_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_subscription_endpoint_idx": {
+          "name": "push_subscription_endpoint_idx",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reactions": {
+      "name": "reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_emoji_url": {
+          "name": "custom_emoji_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reaction_user_note_reaction_idx": {
+          "name": "reaction_user_note_reaction_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reaction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reaction_note_id_idx": {
+          "name": "reaction_note_id_idx",
+          "columns": [
+            {
+              "expression": "note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reactions_user_id_users_id_fk": {
+          "name": "reactions_user_id_users_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reactions_note_id_notes_id_fk": {
+          "name": "reactions_note_id_notes_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.received_activities": {
+      "name": "received_activities",
+      "schema": "",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "received_activities_received_at_idx": {
+          "name": "received_activities_received_at_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_instances": {
+      "name": "remote_instances",
+      "schema": "",
+      "columns": {
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "software_name": {
+          "name": "software_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_color": {
+          "name": "theme_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_registrations": {
+          "name": "open_registrations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "users_count": {
+          "name": "users_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes_count": {
+          "name": "notes_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_blocked": {
+          "name": "is_blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_error_count": {
+          "name": "fetch_error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_fetch_error": {
+          "name": "last_fetch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "remote_instance_software_name_idx": {
+          "name": "remote_instance_software_name_idx",
+          "columns": [
+            {
+              "expression": "software_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "remote_instance_last_fetched_at_idx": {
+          "name": "remote_instance_last_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "last_fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_assignments": {
+      "name": "role_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_by_id": {
+          "name": "assigned_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "role_assignment_user_role_idx": {
+          "name": "role_assignment_user_role_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "role_assignment_user_idx": {
+          "name": "role_assignment_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "role_assignment_role_idx": {
+          "name": "role_assignment_role_idx",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "role_assignments_user_id_users_id_fk": {
+          "name": "role_assignments_user_id_users_id_fk",
+          "tableFrom": "role_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_assignments_role_id_roles_id_fk": {
+          "name": "role_assignments_role_id_roles_id_fk",
+          "tableFrom": "role_assignments",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_assignments_assigned_by_id_users_id_fk": {
+          "name": "role_assignments_assigned_by_id_users_id_fk",
+          "tableFrom": "role_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_admin_role": {
+          "name": "is_admin_role",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_moderator_role": {
+          "name": "is_moderator_role",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "policies": {
+          "name": "policies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "role_name_idx": {
+          "name": "role_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "role_display_order_idx": {
+          "name": "role_display_order_idx",
+          "columns": [
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scheduled_notes": {
+      "name": "scheduled_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cw": {
+          "name": "cw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "local_only": {
+          "name": "local_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reply_id": {
+          "name": "reply_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "renote_id": {
+          "name": "renote_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_ids": {
+          "name": "file_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "published_note_id": {
+          "name": "published_note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scheduled_note_user_id_idx": {
+          "name": "scheduled_note_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scheduled_note_scheduled_at_idx": {
+          "name": "scheduled_note_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scheduled_note_status_idx": {
+          "name": "scheduled_note_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scheduled_note_pending_schedule_idx": {
+          "name": "scheduled_note_pending_schedule_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scheduled_notes_user_id_users_id_fk": {
+          "name": "scheduled_notes_user_id_users_id_fk",
+          "tableFrom": "scheduled_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_notes_published_note_id_notes_id_fk": {
+          "name": "scheduled_notes_published_note_id_notes_id_fk",
+          "tableFrom": "scheduled_notes",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "published_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "token_idx": {
+          "name": "token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_list_members": {
+      "name": "user_list_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "with_replies": {
+          "name": "with_replies",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_list_member_list_user_idx": {
+          "name": "user_list_member_list_user_idx",
+          "columns": [
+            {
+              "expression": "list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_list_member_list_idx": {
+          "name": "user_list_member_list_idx",
+          "columns": [
+            {
+              "expression": "list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_list_member_user_idx": {
+          "name": "user_list_member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_list_members_list_id_user_lists_id_fk": {
+          "name": "user_list_members_list_id_user_lists_id_fk",
+          "tableFrom": "user_list_members",
+          "tableTo": "user_lists",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_list_members_user_id_users_id_fk": {
+          "name": "user_list_members_user_id_users_id_fk",
+          "tableFrom": "user_list_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_lists": {
+      "name": "user_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_list_user_idx": {
+          "name": "user_list_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_list_user_name_idx": {
+          "name": "user_list_user_name_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_lists_user_id_users_id_fk": {
+          "name": "user_lists_user_id_users_id_fk",
+          "tableFrom": "user_lists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_reports": {
+      "name": "user_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_note_id": {
+          "name": "target_note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "resolved_by_id": {
+          "name": "resolved_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "report_reporter_idx": {
+          "name": "report_reporter_idx",
+          "columns": [
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_target_user_idx": {
+          "name": "report_target_user_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_target_note_idx": {
+          "name": "report_target_note_idx",
+          "columns": [
+            {
+              "expression": "target_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_status_idx": {
+          "name": "report_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_created_at_idx": {
+          "name": "report_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_reports_reporter_id_users_id_fk": {
+          "name": "user_reports_reporter_id_users_id_fk",
+          "tableFrom": "user_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_reports_target_user_id_users_id_fk": {
+          "name": "user_reports_target_user_id_users_id_fk",
+          "tableFrom": "user_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_reports_target_note_id_notes_id_fk": {
+          "name": "user_reports_target_note_id_notes_id_fk",
+          "tableFrom": "user_reports",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "target_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_reports_resolved_by_id_users_id_fk": {
+          "name": "user_reports_resolved_by_id_users_id_fk",
+          "tableFrom": "user_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_warnings": {
+      "name": "user_warnings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderator_id": {
+          "name": "moderator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "warning_user_idx": {
+          "name": "warning_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "warning_moderator_idx": {
+          "name": "warning_moderator_idx",
+          "columns": [
+            {
+              "expression": "moderator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "warning_is_read_idx": {
+          "name": "warning_is_read_idx",
+          "columns": [
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "warning_created_at_idx": {
+          "name": "warning_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_warnings_user_id_users_id_fk": {
+          "name": "user_warnings_user_id_users_id_fk",
+          "tableFrom": "user_warnings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_warnings_moderator_id_users_id_fk": {
+          "name": "user_warnings_moderator_id_users_id_fk",
+          "tableFrom": "user_warnings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "moderator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_url": {
+          "name": "banner_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_suspended": {
+          "name": "is_suspended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system_user": {
+          "name": "is_system_user",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inbox": {
+          "name": "inbox",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outbox": {
+          "name": "outbox",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "followers_url": {
+          "name": "followers_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "following_url": {
+          "name": "following_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_inbox": {
+          "name": "shared_inbox",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "also_known_as": {
+          "name": "also_known_as",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "moved_to": {
+          "name": "moved_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moved_at": {
+          "name": "moved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_css": {
+          "name": "custom_css",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ui_settings": {
+          "name": "ui_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_emojis": {
+          "name": "profile_emojis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "storage_quota_mb": {
+          "name": "storage_quota_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "followers_count": {
+          "name": "followers_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "following_count": {
+          "name": "following_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "gone_detected_at": {
+          "name": "gone_detected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_failure_count": {
+          "name": "fetch_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_fetch_attempt_at": {
+          "name": "last_fetch_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fetch_error": {
+          "name": "last_fetch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "username_host_idx": {
+          "name": "username_host_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_idx": {
+          "name": "email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uri_idx": {
+          "name": "uri_idx",
+          "columns": [
+            {
+              "expression": "uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_is_deleted_idx": {
+          "name": "user_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_gone_detected_idx": {
+          "name": "user_gone_detected_idx",
+          "columns": [
+            {
+              "expression": "gone_detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/backend/drizzle/postgres/meta/_journal.json
+++ b/packages/backend/drizzle/postgres/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1765554551098,
       "tag": "0009_blue_blink",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1765556850690,
+      "tag": "0010_overjoyed_living_mummy",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/src/di/container.ts
+++ b/packages/backend/src/di/container.ts
@@ -23,6 +23,7 @@ import type {
   IPasskeyCredentialRepository,
   IPasskeyChallengeRepository,
   IOAuthAccountRepository,
+  IListRepository,
 } from "../interfaces/repositories/index.js";
 import type { IContactRepository } from "../interfaces/repositories/IContactRepository.js";
 import type { IBlockedUsernameRepository } from "../interfaces/repositories/IBlockedUsernameRepository.js";
@@ -51,6 +52,7 @@ import {
   PostgresPasskeyCredentialRepository,
   PostgresPasskeyChallengeRepository,
   PostgresOAuthAccountRepository,
+  PostgresListRepository,
 } from "../repositories/pg/index.js";
 import { PostgresContactRepository } from "../repositories/pg/PostgresContactRepository.js";
 import { PostgresBlockedUsernameRepository } from "../repositories/pg/PostgresBlockedUsernameRepository.js";
@@ -97,6 +99,7 @@ export interface AppContainer {
   oauthAccountRepository: IOAuthAccountRepository;
   contactRepository: IContactRepository;
   blockedUsernameRepository: IBlockedUsernameRepository;
+  listRepository: IListRepository;
   fileStorage: IFileStorage;
   cacheService: ICacheService;
   activityDeliveryQueue: ActivityDeliveryQueue;
@@ -281,6 +284,7 @@ function createRepositories(db: any, dbType: string) {
         oauthAccountRepository: new PostgresOAuthAccountRepository(db),
         contactRepository: new PostgresContactRepository(db),
         blockedUsernameRepository: new PostgresBlockedUsernameRepository(db),
+        listRepository: new PostgresListRepository(db),
       };
 
     case "mysql":

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -43,6 +43,7 @@ import contactRoute from "./routes/contact.js";
 import onboardingRoute from "./routes/onboarding.js";
 import mentionsRoute from "./routes/mentions.js";
 import directRoute from "./routes/direct.js";
+import listsRoute from "./routes/lists.js";
 import mastodonRoute from "./routes/mastodon.js";
 import wsRoute, { websocket } from "./routes/ws.js";
 import packageJson from "../../../package.json";
@@ -98,6 +99,7 @@ app.route("/api/contact", contactRoute);
 app.route("/api/onboarding", onboardingRoute);
 app.route("/api/mentions", mentionsRoute);
 app.route("/api/direct", directRoute);
+app.route("/api/users/lists", listsRoute);
 
 // Mastodon compatible API
 app.route("/api/v1", mastodonRoute);

--- a/packages/backend/src/interfaces/repositories/IListRepository.ts
+++ b/packages/backend/src/interfaces/repositories/IListRepository.ts
@@ -1,0 +1,96 @@
+/**
+ * List Repository Interface
+ *
+ * Defines the contract for list storage operations.
+ * Implementations handle user-created lists (Twitter/X-like lists).
+ *
+ * @module interfaces/repositories/IListRepository
+ */
+
+import type { List, ListMember, ListWithMemberCount, ListMembership } from "shared";
+
+export interface IListRepository {
+  /**
+   * Create a new list
+   */
+  create(list: Omit<List, "createdAt" | "updatedAt">): Promise<List>;
+
+  /**
+   * Find list by ID
+   */
+  findById(id: string): Promise<List | null>;
+
+  /**
+   * Find all lists owned by a user (with member counts)
+   */
+  findByUserId(userId: string): Promise<ListWithMemberCount[]>;
+
+  /**
+   * Find public lists by owner user ID (with member counts)
+   */
+  findPublicByUserId(userId: string): Promise<ListWithMemberCount[]>;
+
+  /**
+   * Check if list name already exists for user
+   */
+  existsByUserIdAndName(userId: string, name: string): Promise<boolean>;
+
+  /**
+   * Update list
+   */
+  update(id: string, data: Partial<Pick<List, "name" | "isPublic">>): Promise<List>;
+
+  /**
+   * Delete list
+   */
+  delete(id: string): Promise<void>;
+
+  /**
+   * Delete all lists owned by a user
+   */
+  deleteByUserId(userId: string): Promise<void>;
+
+  /**
+   * Add member to list
+   */
+  addMember(member: Omit<ListMember, "createdAt">): Promise<ListMember>;
+
+  /**
+   * Remove member from list
+   */
+  removeMember(listId: string, userId: string): Promise<void>;
+
+  /**
+   * Check if user is member of list
+   */
+  isMember(listId: string, userId: string): Promise<boolean>;
+
+  /**
+   * Get list members with user details (paginated)
+   */
+  getMembers(listId: string, limit?: number, offset?: number): Promise<ListMembership[]>;
+
+  /**
+   * Get member user IDs for timeline query
+   */
+  getMemberUserIds(listId: string): Promise<string[]>;
+
+  /**
+   * Count members in list
+   */
+  countMembers(listId: string): Promise<number>;
+
+  /**
+   * Update member settings
+   */
+  updateMember(
+    listId: string,
+    userId: string,
+    data: Partial<Pick<ListMember, "withReplies">>,
+  ): Promise<ListMember>;
+
+  /**
+   * Get lists that contain a specific user (owned by the requester)
+   */
+  findListsContainingUser(userId: string, ownerId: string): Promise<List[]>;
+}

--- a/packages/backend/src/interfaces/repositories/index.ts
+++ b/packages/backend/src/interfaces/repositories/index.ts
@@ -21,3 +21,4 @@ export * from "./IPasskeyCredentialRepository.js";
 export * from "./IPasskeyChallengeRepository.js";
 export * from "./IOAuthAccountRepository.js";
 export * from "./IBlockedUsernameRepository.js";
+export * from "./IListRepository.js";

--- a/packages/backend/src/middleware/di.ts
+++ b/packages/backend/src/middleware/di.ts
@@ -49,6 +49,7 @@ export function diMiddleware() {
     c.set("blockedUsernameService", container.blockedUsernameService);
     c.set("blockedUsernameRepository", container.blockedUsernameRepository);
     c.set("systemAccountService", container.systemAccountService);
+    c.set("listRepository", container.listRepository);
 
     // Also set the container itself for routes that need multiple services
     c.set("container", container);

--- a/packages/backend/src/repositories/pg/PostgresListRepository.ts
+++ b/packages/backend/src/repositories/pg/PostgresListRepository.ts
@@ -1,0 +1,216 @@
+/**
+ * PostgreSQL List Repository
+ *
+ * PostgreSQL implementation of the IListRepository interface.
+ * Handles user-created lists (Twitter/X-like lists).
+ *
+ * @module repositories/pg/PostgresListRepository
+ */
+
+import { eq, and, sql } from "drizzle-orm";
+import type { Database } from "../../db/index.js";
+import { userLists, userListMembers, users } from "../../db/schema/pg.js";
+import type { IListRepository } from "../../interfaces/repositories/IListRepository.js";
+import type { List, ListMember, ListWithMemberCount, ListMembership } from "shared";
+
+export class PostgresListRepository implements IListRepository {
+  constructor(private db: Database) {}
+
+  async create(list: Omit<List, "createdAt" | "updatedAt">): Promise<List> {
+    const now = new Date();
+    const [result] = await this.db
+      .insert(userLists)
+      .values({
+        ...list,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning();
+
+    if (!result) {
+      throw new Error("Failed to create list");
+    }
+
+    return result as List;
+  }
+
+  async findById(id: string): Promise<List | null> {
+    const [result] = await this.db.select().from(userLists).where(eq(userLists.id, id)).limit(1);
+
+    return (result as List) ?? null;
+  }
+
+  async findByUserId(userId: string): Promise<ListWithMemberCount[]> {
+    const results = await this.db
+      .select({
+        list: userLists,
+        memberCount: sql<number>`(
+          SELECT COUNT(*)::int FROM ${userListMembers}
+          WHERE ${userListMembers.listId} = ${userLists.id}
+        )`,
+      })
+      .from(userLists)
+      .where(eq(userLists.userId, userId))
+      .orderBy(userLists.createdAt);
+
+    return results.map((r) => ({
+      ...r.list,
+      memberCount: r.memberCount,
+    })) as ListWithMemberCount[];
+  }
+
+  async findPublicByUserId(userId: string): Promise<ListWithMemberCount[]> {
+    const results = await this.db
+      .select({
+        list: userLists,
+        memberCount: sql<number>`(
+          SELECT COUNT(*)::int FROM ${userListMembers}
+          WHERE ${userListMembers.listId} = ${userLists.id}
+        )`,
+      })
+      .from(userLists)
+      .where(and(eq(userLists.userId, userId), eq(userLists.isPublic, true)))
+      .orderBy(userLists.createdAt);
+
+    return results.map((r) => ({
+      ...r.list,
+      memberCount: r.memberCount,
+    })) as ListWithMemberCount[];
+  }
+
+  async existsByUserIdAndName(userId: string, name: string): Promise<boolean> {
+    const [result] = await this.db
+      .select({ id: userLists.id })
+      .from(userLists)
+      .where(and(eq(userLists.userId, userId), eq(userLists.name, name)))
+      .limit(1);
+
+    return result !== undefined;
+  }
+
+  async update(id: string, data: Partial<Pick<List, "name" | "isPublic">>): Promise<List> {
+    const [result] = await this.db
+      .update(userLists)
+      .set({ ...data, updatedAt: new Date() })
+      .where(eq(userLists.id, id))
+      .returning();
+
+    if (!result) {
+      throw new Error("Failed to update list");
+    }
+
+    return result as List;
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.db.delete(userLists).where(eq(userLists.id, id));
+  }
+
+  async deleteByUserId(userId: string): Promise<void> {
+    await this.db.delete(userLists).where(eq(userLists.userId, userId));
+  }
+
+  async addMember(member: Omit<ListMember, "createdAt">): Promise<ListMember> {
+    const [result] = await this.db
+      .insert(userListMembers)
+      .values({
+        ...member,
+        createdAt: new Date(),
+      })
+      .returning();
+
+    if (!result) {
+      throw new Error("Failed to add member");
+    }
+
+    return result as ListMember;
+  }
+
+  async removeMember(listId: string, userId: string): Promise<void> {
+    await this.db
+      .delete(userListMembers)
+      .where(and(eq(userListMembers.listId, listId), eq(userListMembers.userId, userId)));
+  }
+
+  async isMember(listId: string, userId: string): Promise<boolean> {
+    const [result] = await this.db
+      .select({ id: userListMembers.id })
+      .from(userListMembers)
+      .where(and(eq(userListMembers.listId, listId), eq(userListMembers.userId, userId)))
+      .limit(1);
+
+    return result !== undefined;
+  }
+
+  async getMembers(listId: string, limit = 100, offset = 0): Promise<ListMembership[]> {
+    const results = await this.db
+      .select({
+        member: userListMembers,
+        user: users,
+      })
+      .from(userListMembers)
+      .leftJoin(users, eq(userListMembers.userId, users.id))
+      .where(eq(userListMembers.listId, listId))
+      .limit(limit)
+      .offset(offset);
+
+    return results.map((r) => ({
+      ...r.member,
+      user: r.user
+        ? {
+            id: r.user.id,
+            username: r.user.username,
+            displayName: r.user.displayName,
+            avatarUrl: r.user.avatarUrl,
+            host: r.user.host,
+          }
+        : undefined,
+    })) as ListMembership[];
+  }
+
+  async getMemberUserIds(listId: string): Promise<string[]> {
+    const results = await this.db
+      .select({ userId: userListMembers.userId })
+      .from(userListMembers)
+      .where(eq(userListMembers.listId, listId));
+
+    return results.map((r) => r.userId);
+  }
+
+  async countMembers(listId: string): Promise<number> {
+    const [result] = await this.db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(userListMembers)
+      .where(eq(userListMembers.listId, listId));
+
+    return result?.count ?? 0;
+  }
+
+  async updateMember(
+    listId: string,
+    userId: string,
+    data: Partial<Pick<ListMember, "withReplies">>,
+  ): Promise<ListMember> {
+    const [result] = await this.db
+      .update(userListMembers)
+      .set(data)
+      .where(and(eq(userListMembers.listId, listId), eq(userListMembers.userId, userId)))
+      .returning();
+
+    if (!result) {
+      throw new Error("Failed to update member");
+    }
+
+    return result as ListMember;
+  }
+
+  async findListsContainingUser(userId: string, ownerId: string): Promise<List[]> {
+    const results = await this.db
+      .select({ list: userLists })
+      .from(userLists)
+      .innerJoin(userListMembers, eq(userLists.id, userListMembers.listId))
+      .where(and(eq(userListMembers.userId, userId), eq(userLists.userId, ownerId)));
+
+    return results.map((r) => r.list) as List[];
+  }
+}

--- a/packages/backend/src/repositories/pg/index.ts
+++ b/packages/backend/src/repositories/pg/index.ts
@@ -21,3 +21,4 @@ export * from "./PostgresPasskeyCredentialRepository.js";
 export * from "./PostgresPasskeyChallengeRepository.js";
 export * from "./PostgresOAuthAccountRepository.js";
 export * from "./PostgresBlockedUsernameRepository.js";
+export * from "./PostgresListRepository.js";

--- a/packages/backend/src/routes/lists.ts
+++ b/packages/backend/src/routes/lists.ts
@@ -1,0 +1,422 @@
+/**
+ * Lists API Routes
+ *
+ * Provides Misskey API-compatible endpoints for list management.
+ * Allows users to create, manage, and view custom user lists.
+ *
+ * @module routes/lists
+ */
+
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { requireAuth } from "../middleware/auth.js";
+import { userRateLimit, RateLimitPresets } from "../middleware/rateLimit.js";
+import { ListService } from "../services/ListService.js";
+
+const lists = new Hono();
+
+/**
+ * Helper to create ListService from context
+ */
+function getListService(c: Context): ListService {
+  const listRepository = c.get("listRepository");
+  const userRepository = c.get("userRepository");
+  const noteRepository = c.get("noteRepository");
+  return new ListService(listRepository, userRepository, noteRepository);
+}
+
+/**
+ * POST /api/users/lists/create
+ *
+ * Create a new list
+ *
+ * @auth Required
+ * @body {string} name - List name
+ * @body {boolean} [isPublic=false] - Whether the list is publicly visible
+ * @returns {List} Created list
+ */
+lists.post(
+  "/create",
+  requireAuth(),
+  userRateLimit(RateLimitPresets.write),
+  async (c: Context) => {
+    const user = c.get("user")!;
+    const listService = getListService(c);
+
+    const body = await c.req.json();
+
+    if (!body.name) {
+      return c.json({ error: "name is required" }, 400);
+    }
+
+    try {
+      const list = await listService.createList(user.id, body.name, body.isPublic ?? false);
+      return c.json(list, 201);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to create list";
+      return c.json({ error: message }, 400);
+    }
+  },
+);
+
+/**
+ * POST /api/users/lists/delete
+ *
+ * Delete a list
+ *
+ * @auth Required
+ * @body {string} listId - List ID to delete
+ * @returns {void}
+ */
+lists.post(
+  "/delete",
+  requireAuth(),
+  userRateLimit(RateLimitPresets.write),
+  async (c: Context) => {
+    const user = c.get("user")!;
+    const listService = getListService(c);
+
+    const body = await c.req.json();
+
+    if (!body.listId) {
+      return c.json({ error: "listId is required" }, 400);
+    }
+
+    try {
+      await listService.deleteList(body.listId, user.id);
+      return c.json({ success: true });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to delete list";
+      return c.json({ error: message }, 400);
+    }
+  },
+);
+
+/**
+ * POST /api/users/lists/update
+ *
+ * Update a list
+ *
+ * @auth Required
+ * @body {string} listId - List ID to update
+ * @body {string} [name] - New list name
+ * @body {boolean} [isPublic] - New visibility setting
+ * @returns {List} Updated list
+ */
+lists.post(
+  "/update",
+  requireAuth(),
+  userRateLimit(RateLimitPresets.write),
+  async (c: Context) => {
+    const user = c.get("user")!;
+    const listService = getListService(c);
+
+    const body = await c.req.json();
+
+    if (!body.listId) {
+      return c.json({ error: "listId is required" }, 400);
+    }
+
+    const updateData: { name?: string; isPublic?: boolean } = {};
+    if (body.name !== undefined) updateData.name = body.name;
+    if (body.isPublic !== undefined) updateData.isPublic = body.isPublic;
+
+    if (Object.keys(updateData).length === 0) {
+      return c.json({ error: "At least one field to update is required" }, 400);
+    }
+
+    try {
+      const list = await listService.updateList(body.listId, user.id, updateData);
+      return c.json(list);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to update list";
+      return c.json({ error: message }, 400);
+    }
+  },
+);
+
+/**
+ * POST /api/users/lists/show
+ *
+ * Get list details
+ *
+ * @auth Optional (required for private lists)
+ * @body {string} listId - List ID
+ * @returns {List} List details
+ */
+lists.post("/show", async (c: Context) => {
+  const user = c.get("user");
+  const listService = getListService(c);
+
+  const body = await c.req.json();
+
+  if (!body.listId) {
+    return c.json({ error: "listId is required" }, 400);
+  }
+
+  try {
+    const list = await listService.getList(body.listId, user?.id);
+    if (!list) {
+      return c.json({ error: "List not found" }, 404);
+    }
+    return c.json(list);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to get list";
+    return c.json({ error: message }, 400);
+  }
+});
+
+/**
+ * POST /api/users/lists/list
+ *
+ * Get user's lists
+ *
+ * @auth Optional (shows only public lists for other users)
+ * @body {string} [userId] - User ID (optional, defaults to current user)
+ * @returns {ListWithMemberCount[]} Lists with member counts
+ */
+lists.post("/list", async (c: Context) => {
+  const user = c.get("user");
+  const listService = getListService(c);
+
+  const body = await c.req.json().catch(() => ({}));
+  const targetUserId = body.userId || user?.id;
+
+  if (!targetUserId) {
+    return c.json({ error: "userId is required when not authenticated" }, 400);
+  }
+
+  try {
+    const userLists = await listService.getUserLists(targetUserId, user?.id);
+    return c.json(userLists);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to get lists";
+    return c.json({ error: message }, 400);
+  }
+});
+
+/**
+ * POST /api/users/lists/push
+ *
+ * Add a user to a list
+ *
+ * @auth Required
+ * @body {string} listId - List ID
+ * @body {string} userId - User ID to add
+ * @body {boolean} [withReplies=true] - Include replies in timeline
+ * @returns {ListMember} Created membership
+ */
+lists.post(
+  "/push",
+  requireAuth(),
+  userRateLimit(RateLimitPresets.write),
+  async (c: Context) => {
+    const user = c.get("user")!;
+    const listService = getListService(c);
+
+    const body = await c.req.json();
+
+    if (!body.listId) {
+      return c.json({ error: "listId is required" }, 400);
+    }
+    if (!body.userId) {
+      return c.json({ error: "userId is required" }, 400);
+    }
+
+    try {
+      const member = await listService.addMember(
+        body.listId,
+        body.userId,
+        user.id,
+        body.withReplies ?? true,
+      );
+      return c.json(member, 201);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to add member";
+      return c.json({ error: message }, 400);
+    }
+  },
+);
+
+/**
+ * POST /api/users/lists/pull
+ *
+ * Remove a user from a list
+ *
+ * @auth Required
+ * @body {string} listId - List ID
+ * @body {string} userId - User ID to remove
+ * @returns {void}
+ */
+lists.post(
+  "/pull",
+  requireAuth(),
+  userRateLimit(RateLimitPresets.write),
+  async (c: Context) => {
+    const user = c.get("user")!;
+    const listService = getListService(c);
+
+    const body = await c.req.json();
+
+    if (!body.listId) {
+      return c.json({ error: "listId is required" }, 400);
+    }
+    if (!body.userId) {
+      return c.json({ error: "userId is required" }, 400);
+    }
+
+    try {
+      await listService.removeMember(body.listId, body.userId, user.id);
+      return c.json({ success: true });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to remove member";
+      return c.json({ error: message }, 400);
+    }
+  },
+);
+
+/**
+ * POST /api/users/lists/get-memberships
+ *
+ * Get list members
+ *
+ * @auth Optional (required for private lists)
+ * @body {string} listId - List ID
+ * @body {number} [limit=30] - Maximum number of members to return
+ * @body {number} [offset=0] - Number of members to skip
+ * @returns {ListMembership[]} Members with user details
+ */
+lists.post("/get-memberships", async (c: Context) => {
+  const user = c.get("user");
+  const listService = getListService(c);
+
+  const body = await c.req.json();
+
+  if (!body.listId) {
+    return c.json({ error: "listId is required" }, 400);
+  }
+
+  const limit = body.limit ?? 30;
+  const offset = body.offset ?? 0;
+
+  try {
+    const members = await listService.getMembers(body.listId, user?.id, limit, offset);
+    return c.json(members);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to get members";
+    return c.json({ error: message }, 400);
+  }
+});
+
+/**
+ * POST /api/users/lists/update-membership
+ *
+ * Update member settings in a list
+ *
+ * @auth Required
+ * @body {string} listId - List ID
+ * @body {string} userId - Member user ID
+ * @body {boolean} [withReplies] - Include replies in timeline
+ * @returns {ListMember} Updated membership
+ */
+lists.post(
+  "/update-membership",
+  requireAuth(),
+  userRateLimit(RateLimitPresets.write),
+  async (c: Context) => {
+    const user = c.get("user")!;
+    const listService = getListService(c);
+
+    const body = await c.req.json();
+
+    if (!body.listId) {
+      return c.json({ error: "listId is required" }, 400);
+    }
+    if (!body.userId) {
+      return c.json({ error: "userId is required" }, 400);
+    }
+
+    const updateData: { withReplies?: boolean } = {};
+    if (body.withReplies !== undefined) updateData.withReplies = body.withReplies;
+
+    if (Object.keys(updateData).length === 0) {
+      return c.json({ error: "At least one field to update is required" }, 400);
+    }
+
+    try {
+      const member = await listService.updateMember(body.listId, body.userId, user.id, updateData);
+      return c.json(member);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to update membership";
+      return c.json({ error: message }, 400);
+    }
+  },
+);
+
+/**
+ * GET /api/users/lists/timeline
+ *
+ * Get list timeline (notes from list members)
+ *
+ * @auth Optional (required for private lists)
+ * @query {string} listId - List ID
+ * @query {number} [limit=20] - Maximum number of notes to return
+ * @query {string} [sinceId] - Return notes newer than this ID
+ * @query {string} [untilId] - Return notes older than this ID
+ * @returns {Note[]} Notes from list members
+ */
+lists.get("/timeline", async (c: Context) => {
+  const user = c.get("user");
+  const listService = getListService(c);
+
+  const listId = c.req.query("listId");
+  if (!listId) {
+    return c.json({ error: "listId is required" }, 400);
+  }
+
+  const limit = c.req.query("limit") ? Number.parseInt(c.req.query("limit")!, 10) : 20;
+  const sinceId = c.req.query("sinceId");
+  const untilId = c.req.query("untilId");
+
+  try {
+    const notes = await listService.getListTimeline(listId, user?.id, {
+      limit,
+      sinceId,
+      untilId,
+    });
+    return c.json(notes);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to get timeline";
+    return c.json({ error: message }, 400);
+  }
+});
+
+/**
+ * POST /api/users/lists/get-containing
+ *
+ * Get lists that contain a specific user (owned by the requester)
+ *
+ * @auth Required
+ * @body {string} userId - User ID to check
+ * @returns {List[]} Lists containing the user
+ */
+lists.post("/get-containing", requireAuth(), async (c: Context) => {
+  const user = c.get("user")!;
+  const listService = getListService(c);
+
+  const body = await c.req.json();
+
+  if (!body.userId) {
+    return c.json({ error: "userId is required" }, 400);
+  }
+
+  try {
+    const containingLists = await listService.getListsContainingUser(body.userId, user.id);
+    return c.json(containingLists);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to get lists";
+    return c.json({ error: message }, 400);
+  }
+});
+
+export default lists;

--- a/packages/backend/src/services/ListService.ts
+++ b/packages/backend/src/services/ListService.ts
@@ -1,0 +1,404 @@
+/**
+ * List Management Service
+ *
+ * Handles list creation, management, and member operations.
+ * Integrates with IListRepository for persistence, IUserRepository for user validation,
+ * and INoteRepository for timeline retrieval.
+ *
+ * @module services/ListService
+ */
+
+import type { IListRepository } from "../interfaces/repositories/IListRepository.js";
+import type { IUserRepository } from "../interfaces/repositories/IUserRepository.js";
+import type { INoteRepository, TimelineOptions } from "../interfaces/repositories/INoteRepository.js";
+import type { List, ListMember, ListWithMemberCount, ListMembership } from "shared";
+import type { Note } from "shared";
+import { generateId } from "../../../shared/src/utils/id.js";
+
+/**
+ * List Service
+ *
+ * Provides business logic for list operations including:
+ * - Creating and managing lists
+ * - Adding/removing members from lists
+ * - Retrieving list timelines
+ * - Managing list visibility (public/private)
+ *
+ * @remarks
+ * - List names must be unique per user
+ * - Private lists are only visible to the owner
+ * - List timelines show notes from all members
+ */
+export class ListService {
+  /**
+   * ListService Constructor
+   *
+   * @param listRepository - List repository
+   * @param userRepository - User repository
+   * @param noteRepository - Note repository
+   */
+  constructor(
+    private readonly listRepository: IListRepository,
+    private readonly userRepository: IUserRepository,
+    private readonly noteRepository: INoteRepository,
+  ) {}
+
+  /**
+   * Create a new list
+   *
+   * @param userId - Owner user ID
+   * @param name - List name
+   * @param isPublic - Whether the list is publicly visible (default: false)
+   * @returns Created list
+   * @throws Error if user not found
+   * @throws Error if list name already exists for user
+   *
+   * @example
+   * ```typescript
+   * const list = await listService.createList(userId, "Tech News", true);
+   * ```
+   */
+  async createList(userId: string, name: string, isPublic = false): Promise<List> {
+    // Validate user exists
+    const user = await this.userRepository.findById(userId);
+    if (!user) {
+      throw new Error("User not found");
+    }
+
+    // Check for duplicate name
+    const exists = await this.listRepository.existsByUserIdAndName(userId, name);
+    if (exists) {
+      throw new Error("List name already exists");
+    }
+
+    return await this.listRepository.create({
+      id: generateId(),
+      userId,
+      name,
+      isPublic,
+    });
+  }
+
+  /**
+   * Get a list by ID
+   *
+   * @param listId - List ID
+   * @param requesterId - Requesting user ID (optional, for access control)
+   * @returns List or null if not found/not accessible
+   *
+   * @example
+   * ```typescript
+   * const list = await listService.getList(listId, currentUserId);
+   * ```
+   */
+  async getList(listId: string, requesterId?: string): Promise<List | null> {
+    const list = await this.listRepository.findById(listId);
+    if (!list) {
+      return null;
+    }
+
+    // Check access: owner can always see, others only if public
+    if (!list.isPublic && list.userId !== requesterId) {
+      return null;
+    }
+
+    return list;
+  }
+
+  /**
+   * Get all lists owned by a user
+   *
+   * @param userId - Owner user ID
+   * @param requesterId - Requesting user ID (optional)
+   * @returns Lists with member counts
+   *
+   * @example
+   * ```typescript
+   * const lists = await listService.getUserLists(targetUserId, currentUserId);
+   * ```
+   */
+  async getUserLists(userId: string, requesterId?: string): Promise<ListWithMemberCount[]> {
+    // If requesting own lists, return all
+    if (userId === requesterId) {
+      return await this.listRepository.findByUserId(userId);
+    }
+
+    // Otherwise, return only public lists
+    return await this.listRepository.findPublicByUserId(userId);
+  }
+
+  /**
+   * Update a list
+   *
+   * @param listId - List ID
+   * @param ownerId - Owner user ID (for authorization)
+   * @param data - Update data
+   * @returns Updated list
+   * @throws Error if list not found
+   * @throws Error if not owner
+   * @throws Error if new name already exists
+   *
+   * @example
+   * ```typescript
+   * const updated = await listService.updateList(listId, userId, { name: "New Name" });
+   * ```
+   */
+  async updateList(
+    listId: string,
+    ownerId: string,
+    data: { name?: string; isPublic?: boolean },
+  ): Promise<List> {
+    const list = await this.listRepository.findById(listId);
+    if (!list) {
+      throw new Error("List not found");
+    }
+
+    if (list.userId !== ownerId) {
+      throw new Error("Not authorized to update this list");
+    }
+
+    // Check for duplicate name if changing name
+    if (data.name && data.name !== list.name) {
+      const exists = await this.listRepository.existsByUserIdAndName(ownerId, data.name);
+      if (exists) {
+        throw new Error("List name already exists");
+      }
+    }
+
+    return await this.listRepository.update(listId, data);
+  }
+
+  /**
+   * Delete a list
+   *
+   * @param listId - List ID
+   * @param ownerId - Owner user ID (for authorization)
+   * @throws Error if list not found
+   * @throws Error if not owner
+   *
+   * @example
+   * ```typescript
+   * await listService.deleteList(listId, userId);
+   * ```
+   */
+  async deleteList(listId: string, ownerId: string): Promise<void> {
+    const list = await this.listRepository.findById(listId);
+    if (!list) {
+      throw new Error("List not found");
+    }
+
+    if (list.userId !== ownerId) {
+      throw new Error("Not authorized to delete this list");
+    }
+
+    await this.listRepository.delete(listId);
+  }
+
+  /**
+   * Add a member to a list
+   *
+   * @param listId - List ID
+   * @param targetUserId - User ID to add
+   * @param ownerId - List owner ID (for authorization)
+   * @param withReplies - Whether to include replies in timeline (default: true)
+   * @returns Created membership
+   * @throws Error if list not found
+   * @throws Error if not owner
+   * @throws Error if target user not found
+   * @throws Error if already a member
+   *
+   * @example
+   * ```typescript
+   * const member = await listService.addMember(listId, targetUserId, userId);
+   * ```
+   */
+  async addMember(
+    listId: string,
+    targetUserId: string,
+    ownerId: string,
+    withReplies = true,
+  ): Promise<ListMember> {
+    const list = await this.listRepository.findById(listId);
+    if (!list) {
+      throw new Error("List not found");
+    }
+
+    if (list.userId !== ownerId) {
+      throw new Error("Not authorized to modify this list");
+    }
+
+    // Validate target user exists
+    const targetUser = await this.userRepository.findById(targetUserId);
+    if (!targetUser) {
+      throw new Error("User not found");
+    }
+
+    // Check if already a member
+    const isMember = await this.listRepository.isMember(listId, targetUserId);
+    if (isMember) {
+      throw new Error("User is already a member of this list");
+    }
+
+    return await this.listRepository.addMember({
+      id: generateId(),
+      listId,
+      userId: targetUserId,
+      withReplies,
+    });
+  }
+
+  /**
+   * Remove a member from a list
+   *
+   * @param listId - List ID
+   * @param targetUserId - User ID to remove
+   * @param ownerId - List owner ID (for authorization)
+   * @throws Error if list not found
+   * @throws Error if not owner
+   *
+   * @example
+   * ```typescript
+   * await listService.removeMember(listId, targetUserId, userId);
+   * ```
+   */
+  async removeMember(listId: string, targetUserId: string, ownerId: string): Promise<void> {
+    const list = await this.listRepository.findById(listId);
+    if (!list) {
+      throw new Error("List not found");
+    }
+
+    if (list.userId !== ownerId) {
+      throw new Error("Not authorized to modify this list");
+    }
+
+    await this.listRepository.removeMember(listId, targetUserId);
+  }
+
+  /**
+   * Get list members with user details
+   *
+   * @param listId - List ID
+   * @param requesterId - Requesting user ID (optional, for access control)
+   * @param limit - Maximum number of members to return
+   * @param offset - Number of members to skip
+   * @returns List of memberships with user details
+   * @throws Error if list not found
+   * @throws Error if not authorized to view
+   *
+   * @example
+   * ```typescript
+   * const members = await listService.getMembers(listId, userId, 20, 0);
+   * ```
+   */
+  async getMembers(
+    listId: string,
+    requesterId?: string,
+    limit = 30,
+    offset = 0,
+  ): Promise<ListMembership[]> {
+    const list = await this.listRepository.findById(listId);
+    if (!list) {
+      throw new Error("List not found");
+    }
+
+    // Check access
+    if (!list.isPublic && list.userId !== requesterId) {
+      throw new Error("Not authorized to view this list");
+    }
+
+    return await this.listRepository.getMembers(listId, limit, offset);
+  }
+
+  /**
+   * Update member settings
+   *
+   * @param listId - List ID
+   * @param targetUserId - Member user ID
+   * @param ownerId - List owner ID (for authorization)
+   * @param data - Update data
+   * @returns Updated membership
+   * @throws Error if list not found
+   * @throws Error if not owner
+   *
+   * @example
+   * ```typescript
+   * const updated = await listService.updateMember(listId, targetUserId, userId, { withReplies: false });
+   * ```
+   */
+  async updateMember(
+    listId: string,
+    targetUserId: string,
+    ownerId: string,
+    data: { withReplies?: boolean },
+  ): Promise<ListMember> {
+    const list = await this.listRepository.findById(listId);
+    if (!list) {
+      throw new Error("List not found");
+    }
+
+    if (list.userId !== ownerId) {
+      throw new Error("Not authorized to modify this list");
+    }
+
+    return await this.listRepository.updateMember(listId, targetUserId, data);
+  }
+
+  /**
+   * Get list timeline (notes from all members)
+   *
+   * @param listId - List ID
+   * @param requesterId - Requesting user ID (optional, for access control)
+   * @param options - Timeline options (limit, sinceId, untilId)
+   * @returns Notes from list members
+   * @throws Error if list not found
+   * @throws Error if not authorized to view
+   *
+   * @example
+   * ```typescript
+   * const notes = await listService.getListTimeline(listId, userId, { limit: 20 });
+   * ```
+   */
+  async getListTimeline(
+    listId: string,
+    requesterId?: string,
+    options: Omit<TimelineOptions, "userIds"> = {},
+  ): Promise<Note[]> {
+    const list = await this.listRepository.findById(listId);
+    if (!list) {
+      throw new Error("List not found");
+    }
+
+    // Check access
+    if (!list.isPublic && list.userId !== requesterId) {
+      throw new Error("Not authorized to view this list");
+    }
+
+    // Get member user IDs
+    const memberUserIds = await this.listRepository.getMemberUserIds(listId);
+    if (memberUserIds.length === 0) {
+      return [];
+    }
+
+    // Get timeline for those users
+    return await this.noteRepository.getTimeline({
+      ...options,
+      userIds: memberUserIds,
+    });
+  }
+
+  /**
+   * Get lists that contain a specific user
+   *
+   * @param targetUserId - User ID to check
+   * @param ownerId - List owner ID (returns only lists owned by this user)
+   * @returns Lists containing the target user
+   *
+   * @example
+   * ```typescript
+   * const lists = await listService.getListsContainingUser(targetUserId, currentUserId);
+   * ```
+   */
+  async getListsContainingUser(targetUserId: string, ownerId: string): Promise<List[]> {
+    return await this.listRepository.findListsContainingUser(targetUserId, ownerId);
+  }
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -8,3 +8,4 @@ export * from "./uiSettings.js";
 export * from "./instance.js";
 export * from "./scheduledNote.js";
 export * from "./contact.js";
+export * from "./list.js";

--- a/packages/shared/src/types/list.ts
+++ b/packages/shared/src/types/list.ts
@@ -1,0 +1,62 @@
+/**
+ * List types for user-created lists (Twitter/X-like lists)
+ *
+ * @module types/list
+ */
+
+import type { ID, Timestamps } from "./common.js";
+
+/**
+ * User list entity
+ *
+ * Represents a list created by a user to organize followed users
+ */
+export interface List extends Timestamps {
+  id: ID;
+  /** Owner of the list */
+  userId: ID;
+  /** Display name of the list */
+  name: string;
+  /** Whether the list is publicly visible */
+  isPublic: boolean;
+}
+
+/**
+ * List member entity
+ *
+ * Represents the membership of a user in a list
+ */
+export interface ListMember {
+  id: ID;
+  /** The list this membership belongs to */
+  listId: ID;
+  /** The user who is a member of the list */
+  userId: ID;
+  /** Whether to include replies from this member in list timeline */
+  withReplies: boolean;
+  createdAt: Date;
+}
+
+/**
+ * List with member count
+ *
+ * Extended list type for API responses that include member count
+ */
+export interface ListWithMemberCount extends List {
+  memberCount: number;
+}
+
+/**
+ * List membership with user details
+ *
+ * Used for displaying list members with user information
+ */
+export interface ListMembership extends ListMember {
+  user?: {
+    id: ID;
+    username: string;
+    displayName: string | null;
+    avatarUrl: string | null;
+    host: string | null;
+  };
+}


### PR DESCRIPTION
## Summary

Implement Twitter/X-like list functionality for organizing users into groups with Misskey API-compatible endpoints.

- Add `userLists` and `userListMembers` tables to database schemas (PostgreSQL, MySQL, SQLite)
- Create shared types for `List`, `ListMember`, `ListWithMemberCount`, `ListMembership`
- Implement `IListRepository` interface and `PostgresListRepository`
- Add `ListService` with business logic for list operations
- Create API routes at `/api/users/lists/*` endpoints

### API Endpoints

| Endpoint | Description |
|----------|-------------|
| `POST /api/users/lists/create` | Create a new list |
| `POST /api/users/lists/delete` | Delete a list |
| `POST /api/users/lists/update` | Update list name/visibility |
| `POST /api/users/lists/show` | Get list details |
| `POST /api/users/lists/list` | Get user's lists |
| `POST /api/users/lists/push` | Add user to list |
| `POST /api/users/lists/pull` | Remove user from list |
| `POST /api/users/lists/get-memberships` | Get list members |
| `POST /api/users/lists/update-membership` | Update member settings |
| `GET /api/users/lists/timeline` | Get list timeline |
| `POST /api/users/lists/get-containing` | Get lists containing a user |

### Features

- Public/private list visibility settings
- Per-member "withReplies" setting for timeline filtering
- List timeline retrieval using existing note repository
- Unique list names per user enforced at database level
- Cascade delete for list members when list or user is deleted

Closes #45

## Test plan

- [x] Typecheck passes (`bun run typecheck`)
- [x] Unit tests pass (`bun run test:backend`)
- [ ] Manual testing of list creation/deletion
- [ ] Manual testing of member add/remove
- [ ] Manual testing of list timeline