### PR TITLE
build(frontend): run lingui compile before waku build

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "waku dev",
-    "build": "waku build",
+    "build": "lingui compile && waku build",
     "start": "bun run start.ts",
     "typecheck": "tsc --noEmit",
     "lingui:extract": "lingui extract",


### PR DESCRIPTION
## Summary
- Run `lingui compile` automatically before `waku build` in the frontend build process

## Changes
- **packages/frontend/package.json**: Update build script from `waku build` to `lingui compile && waku build`

## Motivation
Ensures translation files (.js) are generated from .po files during the build process, preventing missing translations in production builds.

## Test plan
- [x] Build completes successfully with `bun run build:frontend`
- [x] `lingui compile` output visible in build logs