### PR TITLE
fix(pwa): add safe area support for iOS Dynamic Island/notch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,7 @@ docker/certs/*-key.pem
 
 # DevContainer environment
 .devcontainer/.env
+
+# cipher data
+cipherdata/
+cipher.yml

--- a/packages/frontend/public/sw.js
+++ b/packages/frontend/public/sw.js
@@ -7,7 +7,7 @@
  */
 
 // Service Worker version - bump this to force cache refresh
-const SW_VERSION = "2.3.0";
+const SW_VERSION = "2.4.0";
 
 // Cache names
 const CACHE_NAME = `rox-cache-v${SW_VERSION}`;

--- a/packages/frontend/src/components/layout/Layout.tsx
+++ b/packages/frontend/src/components/layout/Layout.tsx
@@ -59,8 +59,8 @@ export function Layout({ children, showSidebar = true, maxWidth = "2xl", header 
   // Also add bottom padding on mobile for the AppBar (pb-16 = 4rem = 64px)
   const sidebarMarginClass = shouldShowSidebar
     ? isCollapsed
-      ? "lg:ml-16 pt-16 lg:pt-0 pb-16 lg:pb-0"
-      : "lg:ml-64 pt-16 lg:pt-0 pb-16 lg:pb-0"
+      ? "lg:ml-16 pt-mobile-header pb-16 lg:pb-0"
+      : "lg:ml-64 pt-mobile-header pb-16 lg:pb-0"
     : "";
 
   return (
@@ -72,7 +72,7 @@ export function Layout({ children, showSidebar = true, maxWidth = "2xl", header 
       <main className={`min-h-screen transition-all duration-300 ${sidebarMarginClass}`}>
         {/* Full-width header (e.g., PageHeader) - sticky for consistent navigation */}
         {header && (
-          <div className="sticky top-0 z-30 w-full bg-(--bg-primary)/95 backdrop-blur-sm border-b border-(--border-color)">
+          <div className="sticky sticky-below-mobile-header z-30 w-full bg-(--bg-primary)/95 backdrop-blur-sm border-b border-(--border-color)">
             {header}
           </div>
         )}

--- a/packages/frontend/src/components/layout/Sidebar.tsx
+++ b/packages/frontend/src/components/layout/Sidebar.tsx
@@ -455,7 +455,7 @@ export function Sidebar() {
   return (
     <>
       {/* Mobile Header Bar */}
-      <header className="lg:hidden fixed top-0 left-0 right-0 z-40 bg-(--card-bg) border-b border-(--border-color) px-4 py-3 flex items-center justify-between">
+      <header className="lg:hidden fixed fixed-top-safe left-0 right-0 z-40 bg-(--card-bg) border-b border-(--border-color) px-4 py-3 flex items-center justify-between">
         <button
           type="button"
           onClick={() => setIsMobileMenuOpen(true)}

--- a/packages/frontend/src/styles/globals.css
+++ b/packages/frontend/src/styles/globals.css
@@ -189,8 +189,9 @@ body {
 }
 
 /* PWA Safe Area Support
- * Handles notched devices (iPhone X+) and standalone PWA mode.
+ * Handles notched devices (iPhone X+, Dynamic Island) and standalone PWA mode.
  * Uses env() for safe-area-inset values with fallbacks.
+ * Reference: https://webkit.org/blog/7929/designing-websites-for-iphone-x/
  */
 .safe-area-inset-bottom {
   padding-bottom: env(safe-area-inset-bottom, 0px);
@@ -198,6 +199,18 @@ body {
 
 .safe-area-inset-top {
   padding-top: env(safe-area-inset-top, 0px);
+}
+
+/* Fixed/sticky header support for notched devices (Dynamic Island, notch, status bar)
+ * For elements positioned with `fixed top-0` or `sticky top-0`, use these classes
+ * to position content below the safe area.
+ */
+.fixed-top-safe {
+  top: env(safe-area-inset-top, 0px);
+}
+
+.sticky-top-safe {
+  top: env(safe-area-inset-top, 0px);
 }
 
 /* PWA standalone mode specific adjustments */
@@ -209,6 +222,15 @@ body {
 
   .safe-area-inset-top {
     padding-top: max(env(safe-area-inset-top, 0px), 8px);
+  }
+
+  /* Fixed/sticky headers in PWA mode need top offset for notch/Dynamic Island */
+  .fixed-top-safe {
+    top: env(safe-area-inset-top, 0px);
+  }
+
+  .sticky-top-safe {
+    top: env(safe-area-inset-top, 0px);
   }
 }
 
@@ -227,5 +249,32 @@ body {
       min-height: 100dvh;
       overscroll-behavior: contain;
     }
+  }
+}
+
+/* Mobile sticky header below fixed header (for PageHeader in Layout)
+ * Accounts for fixed header height (64px/4rem) plus safe area inset
+ * Only applied on mobile (< lg breakpoint)
+ */
+.sticky-below-mobile-header {
+  top: calc(4rem + env(safe-area-inset-top, 0px));
+}
+
+@media (min-width: 1024px) {
+  .sticky-below-mobile-header {
+    top: 0;
+  }
+}
+
+/* Mobile content padding below fixed header
+ * Accounts for fixed header height (64px/4rem) plus safe area inset
+ */
+.pt-mobile-header {
+  padding-top: calc(4rem + env(safe-area-inset-top, 0px));
+}
+
+@media (min-width: 1024px) {
+  .pt-mobile-header {
+    padding-top: 0;
   }
 }


### PR DESCRIPTION
## Summary

- Add CSS utility classes for iOS safe area (Dynamic Island/notch) handling
- Fix mobile header overlapping with safe area in PWA standalone mode
- Bump Service Worker version to trigger PWA cache refresh

Fixes #73

## Changes

### CSS (`globals.css`)
- `fixed-top-safe`: positions fixed elements below `env(safe-area-inset-top)`
- `sticky-below-mobile-header`: sticky elements below mobile header (64px) + safe area
- `pt-mobile-header`: content padding below mobile header + safe area

### Components
- **Sidebar.tsx**: Mobile header uses `fixed-top-safe` instead of `top-0`
- **Layout.tsx**: Sticky header and content padding use safe area classes

### PWA
- **sw.js**: Version bumped from 2.3.0 → 2.4.0 for cache refresh

## Test plan

- [ ] Test on iPhone with Dynamic Island (14 Pro+) in PWA mode
- [ ] Test on iPhone with notch (X-13) in PWA mode
- [ ] Verify header is tappable and not obscured by safe area
- [ ] Verify sticky PageHeader scrolls correctly on mobile
- [ ] Verify desktop layout is unaffected