### PR TITLE
feat(api): add Mastodon-compatible /instance/peers endpoint

### DIFF
--- a/packages/backend/src/routes/mastodon.ts
+++ b/packages/backend/src/routes/mastodon.ts
@@ -12,6 +12,7 @@ import type { Context } from "hono";
 import type { INoteRepository } from "../interfaces/repositories/INoteRepository.js";
 import type { IUserRepository } from "../interfaces/repositories/IUserRepository.js";
 import type { ISessionRepository } from "../interfaces/repositories/ISessionRepository.js";
+import type { IRemoteInstanceRepository } from "../interfaces/repositories/IRemoteInstanceRepository.js";
 
 const app = new Hono();
 
@@ -176,6 +177,29 @@ app.get("/directory", async (c: Context) => {
   // "active" order is already handled by the query if supported
 
   return c.json(accounts);
+});
+
+
+/**
+ * Get Instance Peers
+ *
+ * GET /api/v1/instance/peers
+ *
+ * Returns an array of domain names that this instance has federated with.
+ * This endpoint is used by federation monitoring tools (fediverse.observer, etc.)
+ *
+ * Response: Array of domain strings
+ */
+app.get("/instance/peers", async (c: Context) => {
+  const remoteInstanceRepository = c.get("remoteInstanceRepository") as IRemoteInstanceRepository;
+
+  // Get all known remote instances
+  const instances = await remoteInstanceRepository.findAll();
+
+  // Extract just the host domains
+  const peers = instances.map((instance) => instance.host);
+
+  return c.json(peers);
 });
 
 export default app;


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/instance/peers` endpoint for Mastodon API compatibility
- Returns array of domain names this instance has federated with
- Required by federation monitoring tools (fediverse.observer, etc.)

## Background

This endpoint was returning 404, causing warnings in production logs:
```
{"level":40,"method":"GET","path":"/api/v1/instance/peers","status":404}
```

## Implementation

The endpoint queries the `remote_instances` table via `IRemoteInstanceRepository.findAll()` and returns just the host domain names as an array of strings.

Example response:
```json
["mastodon.social", "misskey.io", "pawoo.net"]
```

## Test plan

- [ ] Verify endpoint returns 200: `curl http://localhost:3000/api/v1/instance/peers`
- [ ] Verify response is an array of domain strings
- [ ] Deploy and verify no more 404 errors in logs for this endpoint