### PR TITLE
fix(pwa): add background to safe area and fix scroll-to-top button position

### DIFF
--- a/packages/frontend/public/sw.js
+++ b/packages/frontend/public/sw.js
@@ -7,7 +7,7 @@
  */
 
 // Service Worker version - bump this to force cache refresh
-const SW_VERSION = "2.4.0";
+const SW_VERSION = "2.5.0";
 
 // Cache names
 const CACHE_NAME = `rox-cache-v${SW_VERSION}`;

--- a/packages/frontend/src/components/layout/Sidebar.tsx
+++ b/packages/frontend/src/components/layout/Sidebar.tsx
@@ -455,7 +455,7 @@ export function Sidebar() {
   return (
     <>
       {/* Mobile Header Bar */}
-      <header className="lg:hidden fixed fixed-top-safe left-0 right-0 z-40 bg-(--card-bg) border-b border-(--border-color) px-4 py-3 flex items-center justify-between">
+      <header className="lg:hidden fixed fixed-top-with-safe-area-bg left-0 right-0 z-40 bg-(--card-bg) border-b border-(--border-color) px-4 py-3 flex items-center justify-between">
         <button
           type="button"
           onClick={() => setIsMobileMenuOpen(true)}

--- a/packages/frontend/src/components/ui/ScrollToTop.tsx
+++ b/packages/frontend/src/components/ui/ScrollToTop.tsx
@@ -52,7 +52,7 @@ export function ScrollToTop({ threshold = 400 }: ScrollToTopProps) {
   return (
     <Button
       onPress={scrollToTop}
-      className="fixed bottom-20 right-4 lg:bottom-6 lg:right-6 z-30 p-3 bg-primary-600 hover:bg-primary-700 text-white rounded-full shadow-lg transition-all duration-300 hover:scale-110 outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+      className="fixed scroll-to-top-safe right-4 lg:right-6 z-30 p-3 bg-primary-600 hover:bg-primary-700 text-white rounded-full shadow-lg transition-all duration-300 hover:scale-110 outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
       aria-label="Scroll to top"
     >
       <ArrowUp className="w-5 h-5" />

--- a/packages/frontend/src/styles/globals.css
+++ b/packages/frontend/src/styles/globals.css
@@ -278,3 +278,27 @@ body {
     padding-top: 0;
   }
 }
+
+/* Fixed header with safe area padding (covers entire top area including notch/Dynamic Island)
+ * Use this for headers that should have their background extend into the safe area.
+ * Unlike fixed-top-safe which positions below the safe area, this class positions
+ * at top: 0 and adds padding to push content below the safe area while the
+ * background color fills the entire area.
+ */
+.fixed-top-with-safe-area-bg {
+  top: 0;
+  padding-top: env(safe-area-inset-top, 0px);
+}
+
+/* Scroll to top button positioning for PWA
+ * Accounts for bottom navigation bar (5rem/80px) plus safe area inset for home indicator
+ */
+.scroll-to-top-safe {
+  bottom: calc(5rem + env(safe-area-inset-bottom, 0px));
+}
+
+@media (min-width: 1024px) {
+  .scroll-to-top-safe {
+    bottom: 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary

- Fix Dynamic Island area lacking background color when scrolling
- Fix scroll-to-top button overlapping with home indicator on iOS

## Problem

On iOS PWA (standalone mode):
1. Content was visible through the Dynamic Island/notch area when scrolling because the header was positioned below the safe area with no background above it
2. The scroll-to-top button was positioned at `bottom: 5rem` which didn't account for the home indicator safe area

## Solution

### 1. New `.fixed-top-with-safe-area-bg` class
Unlike `.fixed-top-safe` which positions elements below the safe area, this new class:
- Positions the header at `top: 0`
- Adds `padding-top: env(safe-area-inset-top)` to push content below the safe area
- The background color now extends to cover the entire area including Dynamic Island

### 2. New `.scroll-to-top-safe` class
- Positions the button at `bottom: calc(5rem + env(safe-area-inset-bottom))`
- On desktop, positions at `bottom: 1.5rem` (unchanged)

## Changes

- [globals.css](packages/frontend/src/styles/globals.css): Add new utility classes
- [Sidebar.tsx](packages/frontend/src/components/layout/Sidebar.tsx): Update header class
- [ScrollToTop.tsx](packages/frontend/src/components/ui/ScrollToTop.tsx): Update button positioning
- [sw.js](packages/frontend/public/sw.js): Bump version to 2.5.0

## Test plan

- [ ] iOS PWA: Scroll content and verify header background covers Dynamic Island area
- [ ] iOS PWA: Verify scroll-to-top button doesn't overlap with home indicator
- [ ] Desktop: Verify no visual changes

Closes #78