### PR TITLE
fix(pwa): remove duplicate safe-area calculation causing header gap

### DIFF
--- a/packages/frontend/src/styles/globals.css
+++ b/packages/frontend/src/styles/globals.css
@@ -253,11 +253,11 @@ body {
 }
 
 /* Mobile sticky header below fixed header (for PageHeader in Layout)
- * Accounts for fixed header height (64px/4rem) plus safe area inset
+ * Accounts for fixed header height (64px/4rem). Safe area is handled by the header itself.
  * Only applied on mobile (< lg breakpoint)
  */
 .sticky-below-mobile-header {
-  top: calc(4rem + env(safe-area-inset-top, 0px));
+  top: 4rem;
 }
 
 @media (min-width: 1024px) {
@@ -267,10 +267,10 @@ body {
 }
 
 /* Mobile content padding below fixed header
- * Accounts for fixed header height (64px/4rem) plus safe area inset
+ * Accounts for fixed header height (64px/4rem). Safe area is handled by the header itself.
  */
 .pt-mobile-header {
-  padding-top: calc(4rem + env(safe-area-inset-top, 0px));
+  padding-top: 4rem;
 }
 
 @media (min-width: 1024px) {


### PR DESCRIPTION
## Summary

Fix the gap between the safe-area background and the header content on iOS PWA.

## Problem

After PR #79, a visible gap appeared between the Dynamic Island safe area background and the header content. This was caused by duplicate safe-area-inset-top calculations:

1. **Header** (`fixed-top-with-safe-area-bg`): `top: 0` + `padding-top: env(safe-area-inset-top)`
2. **Content** (`pt-mobile-header`): `padding-top: calc(4rem + env(safe-area-inset-top))`

The safe-area-inset-top was being added twice, once in the header's padding and once in the content's padding.

## Solution

Remove `env(safe-area-inset-top)` from:
- `.pt-mobile-header` - now just `padding-top: 4rem`
- `.sticky-below-mobile-header` - now just `top: 4rem`

The header itself handles the safe area with its padding, so content only needs to account for the header's fixed height (4rem).

## Test plan

- [ ] iOS PWA: Verify no gap between safe area background and header content
- [ ] iOS PWA: Verify sticky elements position correctly below header
- [ ] Desktop: Verify no visual changes