### PR TITLE
fix(pwa): restore safe-area-inset-top for sticky header positioning

### DIFF
--- a/packages/frontend/src/styles/globals.css
+++ b/packages/frontend/src/styles/globals.css
@@ -253,11 +253,13 @@ body {
 }
 
 /* Mobile sticky header below fixed header (for PageHeader in Layout)
- * Accounts for fixed header height (64px/4rem). Safe area is handled by the header itself.
+ * Accounts for fixed header height (64px/4rem) + safe area inset.
+ * The header has padding-top for safe area, so sticky elements must position
+ * below the header's full visual height (4rem + safe-area-inset-top).
  * Only applied on mobile (< lg breakpoint)
  */
 .sticky-below-mobile-header {
-  top: 4rem;
+  top: calc(4rem + env(safe-area-inset-top, 0px));
 }
 
 @media (min-width: 1024px) {


### PR DESCRIPTION
## Summary

- Fixes sticky page headers (e.g., "タイムライン") being overlapped by the fixed header on iOS PWA
- Restores `env(safe-area-inset-top)` to `.sticky-below-mobile-header` class

## Root Cause

PR #80 incorrectly removed `safe-area-inset-top` from `.sticky-below-mobile-header`. While the content padding (`pt-mobile-header`) correctly needs only `4rem`, sticky elements must position below the header's **full visual height** which includes the safe area padding.

### Layout Understanding

| Element | CSS | Explanation |
|---------|-----|-------------|
| Fixed header | `top: 0` + `padding-top: safe-area-inset-top` | Total visual height = `4rem + safe-area-inset-top` |
| Content padding | `padding-top: 4rem` | Correct - content starts from `top: 0` |
| Sticky elements | `top: calc(4rem + safe-area-inset-top)` | **Must account for header's full visual height** |

## Test Plan

- [ ] Test on iOS PWA with Dynamic Island device
- [ ] Verify "タイムライン" and other page headers are not overlapped by the fixed header
- [ ] Confirm no gap between header and sticky content when scrolling

## Related

- Closes #81
- Regression from PR #80