### PR TITLE
fix(pwa): add safe-area-inset-top to content padding

### DIFF
--- a/packages/frontend/src/styles/globals.css
+++ b/packages/frontend/src/styles/globals.css
@@ -269,10 +269,12 @@ body {
 }
 
 /* Mobile content padding below fixed header
- * Accounts for fixed header height (64px/4rem). Safe area is handled by the header itself.
+ * Accounts for fixed header height (64px/4rem) + safe area inset.
+ * The header has padding-top for safe area, so content must also account for
+ * the header's full visual height (4rem + safe-area-inset-top).
  */
 .pt-mobile-header {
-  padding-top: 4rem;
+  padding-top: calc(4rem + env(safe-area-inset-top, 0px));
 }
 
 @media (min-width: 1024px) {


### PR DESCRIPTION
## Summary

- Fixes content (including Timeline) being overlapped by the fixed header on iOS PWA
- Adds `env(safe-area-inset-top)` to `.pt-mobile-header` class

## Root Cause

PR #80 removed `safe-area-inset-top` from both `.sticky-below-mobile-header` and `.pt-mobile-header`. PR #82 restored it for sticky elements, but content padding was missed.

Since the fixed header has `padding-top: safe-area-inset-top`, its visual height is `4rem + safe-area-inset-top`. Content padding must match this to avoid overlap.

### Layout Summary

| Element | CSS Value | Result |
|---------|-----------|--------|
| Fixed header | `top: 0` + `padding-top: safe-area-inset-top` | Visual height = `4rem + safe-area-inset-top` |
| Content padding | `padding-top: calc(4rem + safe-area-inset-top)` | ✅ Now matches header height |
| Sticky elements | `top: calc(4rem + safe-area-inset-top)` | ✅ Fixed in PR #82 |

## Test Plan

- [ ] Test on iOS PWA with Dynamic Island device
- [ ] Verify Timeline and other page content is not overlapped by header
- [ ] Confirm no gap between header and content

## Related

- PR #82 (fixed sticky elements)
- PR #80 (caused this regression)
- Issue #81