### PR TITLE
fix(pwa): fix gap between header and page content on iOS

### DIFF
--- a/packages/frontend/src/components/layout/Sidebar.tsx
+++ b/packages/frontend/src/components/layout/Sidebar.tsx
@@ -455,7 +455,7 @@ export function Sidebar() {
   return (
     <>
       {/* Mobile Header Bar */}
-      <header className="lg:hidden fixed fixed-top-with-safe-area-bg left-0 right-0 z-40 bg-(--card-bg) border-b border-(--border-color) px-4 py-3 flex items-center justify-between">
+      <header className="lg:hidden fixed fixed-top-with-safe-area-bg left-0 right-0 z-40 bg-(--card-bg) border-b border-(--border-color) px-4 pb-3 flex items-center justify-between">
         <button
           type="button"
           onClick={() => setIsMobileMenuOpen(true)}

--- a/packages/frontend/src/styles/globals.css
+++ b/packages/frontend/src/styles/globals.css
@@ -288,10 +288,11 @@ body {
  * Unlike fixed-top-safe which positions below the safe area, this class positions
  * at top: 0 and adds padding to push content below the safe area while the
  * background color fills the entire area.
+ * Includes 0.75rem (py-3 equivalent) padding for content spacing.
  */
 .fixed-top-with-safe-area-bg {
   top: 0;
-  padding-top: env(safe-area-inset-top, 0px);
+  padding-top: calc(0.75rem + env(safe-area-inset-top, 0px));
 }
 
 /* Scroll to top button positioning for PWA


### PR DESCRIPTION
## Summary

- Fixes the gap between the app header and page content (e.g., "タイムライン") on iOS PWA

## Root Cause

The `py-3` class on the header was being **overwritten** by `.fixed-top-with-safe-area-bg`'s `padding-top` property.

```css
/* Tailwind py-3 sets */
padding-top: 0.75rem;
padding-bottom: 0.75rem;

/* fixed-top-with-safe-area-bg overwrites padding-top */
padding-top: env(safe-area-inset-top, 0px);
```

This caused the header's top padding to be only `safe-area-inset-top` instead of `0.75rem + safe-area-inset-top`, making the header shorter than expected and creating a gap.

## Changes

1. **globals.css**: Add `0.75rem` to `fixed-top-with-safe-area-bg` padding calculation:
   ```css
   padding-top: calc(0.75rem + env(safe-area-inset-top, 0px));
   ```

2. **Sidebar.tsx**: Change header from `py-3` to `pb-3` (bottom padding only) to avoid conflict

## Height Calculation

| Component | Height |
|-----------|--------|
| Header padding-top | `0.75rem + safe-area-inset-top` |
| Header content | `~2.5rem` |
| Header padding-bottom | `0.75rem` |
| **Total** | `4rem + safe-area-inset-top` ✅ |

This now matches `sticky-below-mobile-header` and `pt-mobile-header` calculations.

## Test Plan

- [ ] Test on iOS PWA with Dynamic Island device
- [ ] Verify no gap between header bar and page header ("タイムライン")
- [ ] Verify content is not overlapped by header

## Related

- Issue #81
- PR #82, PR #83 (previous fixes)