### PR TITLE
fix(ui): ensure profile avatar appears above banner

### DIFF
--- a/packages/frontend/src/components/user/UserProfile.tsx
+++ b/packages/frontend/src/components/user/UserProfile.tsx
@@ -412,7 +412,7 @@ export function UserProfile({ username, host }: UserProfileProps) {
           <div className="p-4 sm:p-6">
             <div className="flex items-start gap-3 sm:gap-4">
               {/* Avatar */}
-              <div className="-mt-12 sm:-mt-16">
+              <div className="relative z-10 -mt-12 sm:-mt-16">
                 <div className="w-20 h-20 sm:w-24 sm:h-24 rounded-full border-4 border-white dark:border-gray-800 bg-gray-200 dark:bg-gray-700 overflow-hidden">
                   {user.avatarUrl && (
                     <img


### PR DESCRIPTION
## Summary

- Fixes the profile avatar being hidden behind the banner image

## Problem

The avatar uses negative margin (`-mt-12 sm:-mt-16`) to overlap with the banner, but without a `z-index`, it renders below the banner layer.

## Solution

Add `relative z-10` to the avatar container to ensure it appears above the banner.

```tsx
// Before
<div className="-mt-12 sm:-mt-16">

// After  
<div className="relative z-10 -mt-12 sm:-mt-16">
```

## Test Plan

- [ ] View a user profile page
- [ ] Verify the avatar properly overlaps and appears above the banner