### PR TITLE
fix(pwa): add safe area padding to mobile sidebar

### DIFF
--- a/packages/frontend/src/components/layout/Sidebar.tsx
+++ b/packages/frontend/src/components/layout/Sidebar.tsx
@@ -504,12 +504,12 @@ export function Sidebar() {
 
       {/* Mobile Slide-in Menu */}
       <aside
-        className={`lg:hidden fixed left-0 top-0 h-screen w-72 max-w-[85vw] bg-(--card-bg) border-r border-(--border-color) flex flex-col z-50 transform transition-transform duration-300 ease-in-out ${
+        className={`lg:hidden fixed left-0 top-0 h-screen w-72 max-w-[85vw] bg-(--card-bg) border-r border-(--border-color) flex flex-col z-50 transform transition-transform duration-300 ease-in-out pt-[env(safe-area-inset-top)] ${
           isMobileMenuOpen ? "translate-x-0" : "-translate-x-full"
         }`}
       >
-        {/* Close button */}
-        <div className="absolute top-3 right-3">
+        {/* Close button - positioned below safe area */}
+        <div className="absolute top-[calc(0.75rem+env(safe-area-inset-top))] right-3">
           <button
             type="button"
             onClick={() => setIsMobileMenuOpen(false)}


### PR DESCRIPTION
## Summary

- Fixes mobile slide-in sidebar not respecting Dynamic Island / notch safe area on iOS

## Problem

The mobile sidebar was positioned at `top-0` without considering the safe area inset. This caused content to appear behind the Dynamic Island on newer iPhones.

## Changes

1. Add `pt-[env(safe-area-inset-top)]` to the mobile sidebar container
2. Adjust close button position with `top-[calc(0.75rem+env(safe-area-inset-top))]`

## Test Plan

- [ ] Open mobile sidebar on iOS PWA with Dynamic Island
- [ ] Verify sidebar content starts below the safe area
- [ ] Verify close button is accessible and not hidden by Dynamic Island