### PR TITLE
fix(api): convert Buffer to Uint8Array for Response compatibility

### DIFF
--- a/packages/backend/src/routes/startup-image.ts
+++ b/packages/backend/src/routes/startup-image.ts
@@ -243,7 +243,7 @@ app.get("/:width/:height", async (c: Context) => {
     // Generate PNG
     const pngBuffer = await image.png().toBuffer();
 
-    return new Response(pngBuffer, {
+    return new Response(new Uint8Array(pngBuffer), {
       headers: {
         "Content-Type": "image/png",
         "Cache-Control": "public, max-age=86400", // Cache for 24 hours


### PR DESCRIPTION
## Summary

Fixes TypeDoc CI failure caused by type incompatibility between `Buffer` and `Response` body.

## Problem

```
TS2345: Argument of type 'Buffer<ArrayBufferLike>' is not assignable to parameter of type 'BodyInit | null | undefined'.
```

The `Response` constructor expects `BodyInit` which doesn't directly accept Node.js `Buffer`.

## Solution

Wrap the buffer in `Uint8Array`:

```typescript
// Before
return new Response(pngBuffer, { ... });

// After
return new Response(new Uint8Array(pngBuffer), { ... });
```

## Test Plan

- [ ] TypeDoc generation succeeds
- [ ] Startup image endpoint still works correctly