### PR TITLE
fix(api): convert Buffer to Uint8Array for Response compatibility

### DIFF
--- a/packages/backend/src/routes/startup-image.ts
+++ b/packages/backend/src/routes/startup-image.ts
@@ -243,7 +243,7 @@ app.get("/:width/:height", async (c: Context) => {
     // Generate PNG
     const pngBuffer = await image.png().toBuffer();
 
-    return new Response(pngBuffer, {
+    return new Response(new Uint8Array(pngBuffer), {
       headers: {
         "Content-Type": "image/png",
         "Cache-Control": "public, max-age=86400", // Cache for 24 hours


### PR DESCRIPTION
## Summary

Hotfix for TypeDoc CI failure in v2025.12.3.

## Problem

The TypeDoc documentation generation workflow failed due to a type incompatibility:

```
TS2345: Argument of type 'Buffer<ArrayBufferLike>' is not assignable to parameter of type 'BodyInit | null | undefined'.
```

## Solution

Convert `Buffer` to `Uint8Array` when passing to `Response` constructor:

```typescript
// Before
return new Response(pngBuffer, { ... });

// After
return new Response(new Uint8Array(pngBuffer), { ... });
```

## Changes

- [startup-image.ts](packages/backend/src/routes/startup-image.ts): Wrap buffer in `Uint8Array` for Response compatibility

## Test Plan

- [x] Local typecheck passes
- [ ] TypeDoc generation succeeds in CI