### PR TITLE
fix(deck): reset scroll to left on load and fix mobile AppBar overlap

### DIFF
--- a/packages/frontend/src/components/deck/DeckLayout.tsx
+++ b/packages/frontend/src/components/deck/DeckLayout.tsx
@@ -285,7 +285,7 @@ export function DeckLayout({
         {/* Mobile: Single column with swipe */}
         {/* Height: 100vh - header (4rem + safe-area) - AppBar (3.5rem) - safe-area-bottom */}
         <div
-          className="lg:hidden overflow-hidden pb-14"
+          className="lg:hidden overflow-hidden"
           style={{
             height: "calc(100vh - 4rem - env(safe-area-inset-top, 0px) - 3.5rem - env(safe-area-inset-bottom, 0px))",
           }}
@@ -314,7 +314,7 @@ export function DeckLayout({
           {/* Mobile Column Indicators - positioned above AppBar (h-14 = 3.5rem) */}
           {columns.length > 1 && (
             <div
-              className="fixed left-0 right-0 flex justify-center gap-2 pb-2 z-10"
+              className="fixed left-0 right-0 flex justify-center gap-2 pb-2 z-50"
               style={{ bottom: "calc(3.5rem + env(safe-area-inset-bottom, 0px) + 0.5rem)" }}
             >
               {columns.map((col, index) => (
@@ -335,7 +335,7 @@ export function DeckLayout({
           {/* Swipe hint for first-time users - positioned above indicators */}
           {columns.length > 1 && mobileColumnIndex === 0 && (
             <div
-              className="fixed left-0 right-0 flex justify-center pointer-events-none"
+              className="fixed left-0 right-0 flex justify-center pointer-events-none z-50"
               style={{ bottom: "calc(3.5rem + env(safe-area-inset-bottom, 0px) + 2rem)" }}
             >
               <div className="text-xs text-gray-400 dark:text-gray-500 flex items-center gap-1">


### PR DESCRIPTION
## Summary
- Fix deck view scrolling to rightmost position on reload - now resets to leftmost (first column)
- Fix mobile deck display content overlapping with AppBar at bottom

## Changes
- Added `useEffect` to reset scroll position to 0 when profile changes or on initial load
- Fixed mobile container height calculation to properly account for header, AppBar, and safe areas
- Adjusted column indicators positioning to stay above AppBar
- Adjusted swipe hint positioning to stay above column indicators

## Test plan
- [ ] Desktop: Reload deck view and verify it shows the first (leftmost) column
- [ ] Desktop: Switch deck profiles and verify scroll resets to first column
- [ ] Mobile: Verify deck content does not overlap with bottom AppBar
- [ ] Mobile: Verify column indicators are visible above AppBar
- [ ] Mobile: Verify swipe hint is visible above column indicators

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * プロフィール変更時および初回読み込み時にモバイルデッキビューが確実にリセットされるようになりました

* **スタイル**
  * モバイル表示の高さ計算をヘッダー・セーフエリア・下部UIに合わせて動的に調整しました
  * インジケーターを左右に広がる固定コンテナへ移動し、下部UIの上に表示するよう改善しました
  * スワイプヒントの表示位置をインジケーターの上に移動しました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->