### PR TITLE
feat(Card): add InteractiveCard with React Aria and clarify RAC guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,53 @@ Japanese documentation is provided in parallel to support the local community.
 | Queue | Dragonfly / BullMQ | Async job processing for ActivityPub delivery (VPS environments) |
 | Code Quality | oxc | Rust-based toolchain for linting and formatting (replaces ESLint/Prettier) |
 
+### React Aria Components Usage Guidelines
+
+React Aria Components should be used for **interactive UI elements** that require:
+
+- Keyboard navigation and focus management
+- Screen reader announcements and ARIA attributes
+- Complex interaction patterns (dialogs, menus, selects)
+- Touch and pointer event handling
+
+**When to use React Aria Components:**
+
+| Component Type | Use React Aria | Reason |
+|---------------|----------------|--------|
+| Button, Link | ✅ Yes | Keyboard/focus/press events |
+| TextField, TextArea | ✅ Yes | Input accessibility, validation |
+| Select, ComboBox | ✅ Yes | Complex keyboard navigation |
+| Dialog, Modal | ✅ Yes | Focus trapping, backdrop handling |
+| Switch, Checkbox | ✅ Yes | Toggle state announcements |
+| Menu, Popover | ✅ Yes | Focus management, dismiss handling |
+| Tabs, TabPanel | ✅ Yes | Arrow key navigation |
+
+**When simple styled containers are appropriate:**
+
+| Component Type | Use React Aria | Reason |
+|---------------|----------------|--------|
+| Card (static) | ❌ No | Visual grouping only, no interaction |
+| CardHeader, CardContent | ❌ No | Semantic HTML sufficient |
+| Layout containers | ❌ No | No user interaction |
+| Decorative elements | ❌ No | Not interactive |
+
+**Special case - Interactive Cards:**
+
+For cards that respond to user interaction (click/press), use the `InteractiveCard` component which wraps React Aria's Button for proper accessibility:
+
+```tsx
+// Static card (no click handler) - uses div
+<Card>
+  <CardHeader>Title</CardHeader>
+  <CardContent>Content</CardContent>
+</Card>
+
+// Interactive card (has press handler) - uses React Aria Button
+<InteractiveCard onPress={() => navigate('/detail')}>
+  <p>Click to view details</p>
+</InteractiveCard>
+```
+
 ## Development Commands
 
 ### Running the Application


### PR DESCRIPTION
## Summary

- Refactor `Card` component to focus on static content display (presentational container)
- Add `InteractiveCard` component using React Aria `Button` for clickable cards with full accessibility support
- Update `CLAUDE.md` with clear guidelines on when to use React Aria Components vs simple styled containers

## Changes

### Card Component (`packages/frontend/src/components/ui/Card.tsx`)

**Before:**
- Single `Card` component that rendered as `<button>` when `onClick` was provided
- Basic accessibility through manual ARIA attributes

**After:**
- `Card` - Static presentational container using `<div>` for visual grouping
- `InteractiveCard` - Interactive card using React Aria `Button` with:
  - Proper keyboard navigation (Enter/Space to activate)
  - Focus ring styling via `isFocusVisible` render prop
  - Press state animation (`scale-[0.98]`)
  - Disabled state handling with `opacity-50`
  - Screen reader announcements

### Guidelines (`CLAUDE.md`)

Added "React Aria Components Usage Guidelines" section with:
- Clear criteria for when to use RAC (interactive elements)
- Decision matrix for common component types
- Examples of `Card` vs `InteractiveCard` usage

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run test:unit` passes (872 tests)
- [ ] Manual verification of InteractiveCard keyboard navigation
- [ ] Manual verification of focus ring appearance

Closes #97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * インタラクティブなカード要素用の InteractiveCard コンポーネントを追加しました。

* **ドキュメント**
  * React Aria コンポーネントの使用ガイドラインを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->