### PR TITLE
fix(DeckLayout): lower z-index of mobile deck indicators to appear below sidebar

### DIFF
--- a/packages/frontend/src/components/deck/DeckLayout.tsx
+++ b/packages/frontend/src/components/deck/DeckLayout.tsx
@@ -311,10 +311,11 @@ export function DeckLayout({
             </div>
           )}
 
-          {/* Mobile Column Indicators - positioned above AppBar (h-14 = 3.5rem) */}
+          {/* Mobile Column Indicators - positioned above AppBar (h-14 = 3.5rem)
+              z-30 ensures indicators are below mobile header (z-40) and sidebar (z-50) */}
           {columns.length > 1 && (
             <div
-              className="fixed left-0 right-0 flex justify-center gap-2 pb-2 z-50"
+              className="fixed left-0 right-0 flex justify-center gap-2 pb-2 z-30"
               style={{ bottom: "calc(3.5rem + env(safe-area-inset-bottom, 0px) + 0.5rem)" }}
             >
               {columns.map((col, index) => (
@@ -332,10 +333,11 @@ export function DeckLayout({
             </div>
           )}
 
-          {/* Swipe hint for first-time users - positioned above indicators */}
+          {/* Swipe hint for first-time users - positioned above indicators
+              z-30 ensures hint is below mobile header (z-40) and sidebar (z-50) */}
           {columns.length > 1 && mobileColumnIndex === 0 && (
             <div
-              className="fixed left-0 right-0 flex justify-center pointer-events-none z-50"
+              className="fixed left-0 right-0 flex justify-center pointer-events-none z-30"
               style={{ bottom: "calc(3.5rem + env(safe-area-inset-bottom, 0px) + 2rem)" }}
             >
               <div className="text-xs text-gray-400 dark:text-gray-500 flex items-center gap-1">


### PR DESCRIPTION
## Summary

- Fixed z-index layering issue where mobile deck column indicators and "Swipe to navigate" hint appeared above the sidebar
- Changed z-index from `z-50` to `z-30` for both elements

## Z-index Hierarchy

| Element | Z-index |
|---------|---------|
| Deck indicators/swipe hint | z-30 (changed from z-50) |
| Mobile header | z-40 |
| Sidebar overlay and menu | z-50 |

## Test plan

- [ ] Open deck view on mobile
- [ ] Open sidebar menu
- [ ] Verify that the column indicators and swipe hint are hidden behind the sidebar

Fixes #100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* モバイルUIのレイヤリング順序を調整しました。カラムインジケーターとスワイプヒント（初回ユーザー向け）がヘッダーとサイドバーの下に正しく表示されるようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->