### PR TITLE
fix(deck): enable real-time updates and mobile profile management

### DIFF
--- a/packages/frontend/src/components/deck/DeckLayout.tsx
+++ b/packages/frontend/src/components/deck/DeckLayout.tsx
@@ -239,9 +239,16 @@ export function DeckLayout({
       <main
         className={`min-h-screen transition-all duration-300 ${sidebarMarginClass} pt-mobile-header lg:pt-0`}
       >
-        {/* Deck Header - Profile Switcher */}
+        {/* Deck Header - Profile Switcher (Desktop) */}
         {showProfileSwitcher && (
           <div className="sticky top-0 z-20 bg-gray-100 dark:bg-gray-950 border-b border-(--border-color) px-4 py-2 hidden lg:block">
+            <DeckProfileSwitcher />
+          </div>
+        )}
+
+        {/* Deck Header - Profile Switcher (Mobile) */}
+        {showProfileSwitcher && (
+          <div className="sticky top-0 z-20 bg-gray-100 dark:bg-gray-950 border-b border-(--border-color) px-2 py-1.5 lg:hidden">
             <DeckProfileSwitcher />
           </div>
         )}
@@ -283,11 +290,13 @@ export function DeckLayout({
         </div>
 
         {/* Mobile: Single column with swipe */}
-        {/* Height: 100vh - header (4rem + safe-area) - AppBar (3.5rem) - safe-area-bottom */}
+        {/* Height: 100vh - header (4rem + safe-area) - profile switcher (~2.5rem) - AppBar (3.5rem) - safe-area-bottom */}
         <div
           className="lg:hidden overflow-hidden"
           style={{
-            height: "calc(100vh - 4rem - env(safe-area-inset-top, 0px) - 3.5rem - env(safe-area-inset-bottom, 0px))",
+            height: showProfileSwitcher
+              ? "calc(100vh - 4rem - env(safe-area-inset-top, 0px) - 2.5rem - 3.5rem - env(safe-area-inset-bottom, 0px))"
+              : "calc(100vh - 4rem - env(safe-area-inset-top, 0px) - 3.5rem - env(safe-area-inset-bottom, 0px))",
           }}
           onTouchStart={handleTouchStart}
           onTouchMove={handleTouchMove}

--- a/packages/frontend/src/components/deck/columns/TimelineColumn.tsx
+++ b/packages/frontend/src/components/deck/columns/TimelineColumn.tsx
@@ -83,8 +83,12 @@ export function TimelineColumnContent({
           ? "global"
           : "local";
 
-  // Enable real-time updates
-  useTimelineStream(streamType, { enabled: true, onNewNote: handleNewNote });
+  // Enable real-time updates with column-scoped state
+  useTimelineStream(streamType, {
+    enabled: true,
+    onNewNote: handleNewNote,
+    columnId,
+  });
 
   // Load initial data
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Fix deck view auto-refresh not working by correctly routing WebSocket updates to column-scoped atoms
- Add profile switcher to mobile deck view so users can manage profiles on mobile devices

## Problem
1. **Auto-refresh not working**: `useTimelineStream` hook was updating the global `timelineNotesAtom`, but `TimelineColumn` was reading from column-scoped `columnNotesStateAtomFamily(columnId)`. These are different atoms, so WebSocket updates never reached the deck columns.

2. **No mobile profile management**: The deck profile switcher was hidden on mobile (`hidden lg:block`), preventing mobile users from switching or managing profiles.

## Solution
1. Added `columnId` option to `useTimelineStream` hook. When provided, WebSocket callbacks update column-scoped atoms instead of the global timeline atom.

2. Added a mobile version of the profile switcher to `DeckLayout` that displays on screens smaller than `lg` (1024px).

## Changes
- `packages/frontend/src/hooks/useTimelineStream.ts`: Added `columnId` option and column-scoped atom setters
- `packages/frontend/src/components/deck/columns/TimelineColumn.tsx`: Pass `columnId` to `useTimelineStream`
- `packages/frontend/src/components/deck/DeckLayout.tsx`: Added mobile profile switcher and adjusted height calculation

## Test plan
- [ ] Open deck view on desktop, verify new notes appear in real-time
- [ ] Open deck view on mobile, verify new notes appear in real-time
- [ ] On mobile, verify profile switcher is visible and functional
- [ ] Verify switching profiles works correctly on mobile
- [ ] Verify column swipe navigation still works after adding profile switcher

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

**新機能**
* モバイルデバイス向けプロファイルスイッチャーUIを改善し、画面サイズに応じた表示最適化に対応
* デッキビューでのカラム単位リアルタイムアップデート機能をサポート
* モバイルビューポートのレイアウト高さを動的に調整し、UI要素の表示に応じた表示領域の最適化を実施

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->