### PR TITLE
fix: improve DM log privacy by logging only recipient counts

### DIFF
--- a/packages/backend/src/services/NoteService.ts
+++ b/packages/backend/src/services/NoteService.ts
@@ -248,14 +248,13 @@ export class NoteService {
     // Deliver ActivityPub activity (async, non-blocking)
     const author = await this.userRepository.findById(userId);
 
-    // Log DM delivery decision for debugging
+    // Log DM delivery decision for debugging (only counts for privacy)
     if (visibility === "specified") {
-      logger.info(
+      logger.debug(
         {
           noteId,
           visibility,
-          visibleUserIds,
-          visibleUserIdsLength: visibleUserIds.length,
+          visibleUserIdsCount: visibleUserIds.length,
           authorExists: !!author,
           authorHost: author?.host,
           localOnly,
@@ -267,7 +266,7 @@ export class NoteService {
     if (author && !author.host && !localOnly) {
       if (visibility === "specified" && visibleUserIds.length > 0) {
         // Direct message: deliver to specific recipients
-        logger.info({ noteId, visibleUserIds }, "Starting DM delivery");
+        logger.debug({ noteId, recipientCount: visibleUserIds.length }, "Starting DM delivery");
         this.deliveryService
           .deliverDirectMessage(note, author, visibleUserIds)
           .catch((error) => {


### PR DESCRIPTION
## Summary
- Remove `visibleUserIds` array from info-level logs to protect recipient privacy
- Change DM-related logs from `info` to `debug` level
- Log only counts (`visibleUserIdsCount`, `recipientCount`) instead of full user ID arrays

## Changes
- `packages/backend/src/services/NoteService.ts`
  - Line 253: Changed `logger.info` → `logger.debug`, removed `visibleUserIds` array
  - Line 270: Changed `logger.info` → `logger.debug`, log `recipientCount` instead of `visibleUserIds`

## Test plan
- [x] Type check passes
- [x] Unit tests pass (970 tests)
- [ ] Verify DM delivery still works correctly in production

Closes #122

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **チューニング・改善**
  * ダイレクトメッセージ配信システムのログ処理を最適化しました。プライバシー保護を強化しながら、ログ管理の効率性を改善しています。配信ロジックの動作に変更はありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->