### PR TITLE
chore: bump version to 2026.4.0-alpha.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rox",
-  "version": "2026.4.0-alpha.3",
+  "version": "2026.4.0-alpha.4",
   "license": "AGPL-3.0-only",
   "devDependencies": {
     "@playwright/test": "^1.59.1",


### PR DESCRIPTION
絵文字フェッチ重複排除・WebSocket接続チャーン修正後のバージョンバンプ。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * パッケージバージョンを 2026.4.0-alpha.4 に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->