### PR TITLE
fix(frontend): use window.location.href for profile back navigation

### DIFF
--- a/packages/frontend/src/hooks/useSafeNavigation.ts
+++ b/packages/frontend/src/hooks/useSafeNavigation.ts
@@ -174,21 +174,17 @@ export function useSafeNavigation(): SafeNavigationResult {
   );
 
   /**
-   * Go back in history using full page navigation
+   * Go back to the previous page.
    *
-   * Go back to the previous page using SPA navigation.
+   * Uses window.location.href for reliable navigation in production builds
+   * where Waku's router.push may update the URL without re-rendering content.
    */
   const goBack = useCallback(async () => {
     await closeModalsAndWait();
 
     const previousPath = getPreviousPath("/timeline");
-
-    try {
-      router.push(previousPath as `/${string}`);
-    } catch {
-      window.location.href = previousPath;
-    }
-  }, [closeModalsAndWait, router]);
+    window.location.href = previousPath;
+  }, [closeModalsAndWait]);
 
   return {
     isNavigating,


### PR DESCRIPTION
## Summary

プロフィール画面の「← Back」ボタンを押すとURLは `/timeline` に変わるが、画面がプロフィールのまま更新されない問題を修正。

## Root Cause

Waku の `router.push` が本番ビルドでURLのみ変更しコンテンツの再レンダリングに失敗する。開発環境（`waku dev`）では正常に動作するが、本番ビルド（`waku build` + `waku start`）では RSC のルーティングが異なる動作をする。

## Fix

`goBack` を `window.location.href` に戻す。前のページに「戻る」操作ではフルリロードでも UX への影響は最小限。通常の前方遷移 (`navigate`) は引き続き `router.push` を使用。

## Test plan

- [x] 型チェック通過
- [ ] 本番環境でプロフィール → Back → タイムラインが正しく表示されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * ナビゲーション機能の動作を改善し、戻る操作がより安定して動作するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->