### PR TITLE
fix(frontend): remove history.pushState monkey-patch and flushSync from navigation

### DIFF
--- a/packages/frontend/src/components/AppProviders.tsx
+++ b/packages/frontend/src/components/AppProviders.tsx
@@ -101,9 +101,13 @@ export function AppProviders({ children }: AppProvidersProps) {
     return () => window.removeEventListener("error", handleError);
   }, []);
 
-  // Track navigation history for proper back button functionality
+  // Track navigation history for proper back button functionality.
+  // IMPORTANT: Do NOT monkey-patch history.pushState/replaceState here.
+  // Patching pushState interferes with Waku's internal RSC routing,
+  // causing router.push to update the URL without re-rendering content.
+  // Instead, record navigation via popstate events and a custom event
+  // dispatched after SPA navigations complete.
   useEffect(() => {
-    // Get full path including search params and hash
     const getFullPath = () =>
       window.location.pathname + window.location.search + window.location.hash;
 
@@ -115,26 +119,17 @@ export function AppProviders({ children }: AppProvidersProps) {
       recordNavigation(getFullPath());
     };
 
-    // Listen for pushstate/replacestate by patching history methods
-    const originalPushState = history.pushState.bind(history);
-    const originalReplaceState = history.replaceState.bind(history);
-
-    history.pushState = (...args) => {
-      originalPushState(...args);
+    // Listen for custom navigation event dispatched by SpaLink/router
+    const handleNavigation = () => {
       recordNavigation(getFullPath());
     };
 
-    history.replaceState = (...args) => {
-      originalReplaceState(...args);
-      // Don't record replaceState as it's typically used for in-place updates
-    };
-
     window.addEventListener("popstate", handlePopState);
+    window.addEventListener("rox-navigation", handleNavigation);
 
     return () => {
       window.removeEventListener("popstate", handlePopState);
-      history.pushState = originalPushState;
-      history.replaceState = originalReplaceState;
+      window.removeEventListener("rox-navigation", handleNavigation);
     };
   }, []);
 

--- a/packages/frontend/src/components/ui/SpaLink.tsx
+++ b/packages/frontend/src/components/ui/SpaLink.tsx
@@ -37,14 +37,28 @@ export interface SpaLinkProps extends Omit<ComponentProps<"a">, "href"> {
  * </SpaLink>
  * ```
  */
-export function SpaLink({ to, children, prefetchOnEnter, className, ...props }: SpaLinkProps) {
-  // Cast to 'any' to bypass Waku's strict route typing
-  // This allows dynamic routes like user profiles (/:username)
+export function SpaLink({
+  to,
+  children,
+  prefetchOnEnter,
+  className,
+  onClick,
+  ...props
+}: SpaLinkProps) {
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    onClick?.(e);
+    // Notify navigation history tracker after Waku processes the click
+    requestAnimationFrame(() => {
+      window.dispatchEvent(new Event("rox-navigation"));
+    });
+  };
+
   return (
     <Link
       to={to as `/${string}`}
       className={className}
       unstable_prefetchOnEnter={prefetchOnEnter}
+      onClick={handleClick}
       {...props}
     >
       {children}

--- a/packages/frontend/src/hooks/useSafeNavigation.ts
+++ b/packages/frontend/src/hooks/useSafeNavigation.ts
@@ -143,13 +143,15 @@ export function useSafeNavigation(): SafeNavigationResult {
           if (urlMatches && newContent === currentContent && currentContent !== "") {
             // URL changed but content didn't — RSC fetch was skipped, fall back
             window.location.href = path;
+          } else {
+            setIsNavigating(false);
           }
         }, 500);
       } catch {
         window.location.href = path;
       }
     },
-    [router],
+    [router, setIsNavigating],
   );
 
   /**

--- a/packages/frontend/src/hooks/useSafeNavigation.ts
+++ b/packages/frontend/src/hooks/useSafeNavigation.ts
@@ -3,17 +3,14 @@
 /**
  * Safe Navigation Hook
  *
- * Provides navigation functions that properly close all modals
- * before navigating to prevent portal cleanup errors.
- *
- * Uses full page navigation to avoid Waku/React portal cleanup issues
- * during SPA transitions.
+ * Provides navigation functions that close modals before navigating.
+ * Avoids flushSync and requestAnimationFrame to prevent interfering
+ * with Waku's RSC routing transitions.
  *
  * @module hooks/useSafeNavigation
  */
 
 import { useCallback, useState } from "react";
-import { flushSync } from "react-dom";
 import { useSetAtom } from "jotai";
 import { closeAllModalsAtom } from "../lib/atoms/modals";
 import { useRouter } from "../components/ui/SpaLink";
@@ -44,25 +41,43 @@ function getNavigationHistory(): string[] {
  */
 function getPreviousPath(fallback: string): string {
   const history = getNavigationHistory();
-  // Use full path including search params and hash for accurate matching
   const currentPath =
     typeof window !== "undefined"
       ? window.location.pathname + window.location.search + window.location.hash
       : "";
 
-  // Find current page in history and get the one before it
   const currentIndex = history.lastIndexOf(currentPath);
 
   if (currentIndex > 0) {
     return history[currentIndex - 1] || fallback;
   }
 
-  // Current page not in history, use last entry if different
   if (history.length > 0 && history[history.length - 1] !== currentPath) {
     return history[history.length - 1] || fallback;
   }
 
   return fallback;
+}
+
+/**
+ * Close all open popovers using DOM events
+ */
+function closeUncontrolledPopovers(): void {
+  const escapeEvent = new KeyboardEvent("keydown", {
+    key: "Escape",
+    code: "Escape",
+    keyCode: 27,
+    bubbles: true,
+    cancelable: true,
+  });
+
+  document.querySelectorAll('[data-open], button[aria-expanded="true"]').forEach((el) => {
+    el.dispatchEvent(escapeEvent);
+  });
+
+  document.querySelectorAll("[data-react-aria-top-layer]").forEach((el) => {
+    el.dispatchEvent(escapeEvent);
+  });
 }
 
 /**
@@ -78,52 +93,14 @@ interface SafeNavigationResult {
 }
 
 /**
- * Close all open popovers using DOM events
+ * Hook for safe navigation that closes modals before navigating.
  *
- * This handles uncontrolled MenuTrigger/Select popovers that aren't
- * in the modal registry. We dispatch an Escape key event to close them.
- */
-function closeUncontrolledPopovers(): void {
-  const escapeEvent = new KeyboardEvent("keydown", {
-    key: "Escape",
-    code: "Escape",
-    keyCode: 27,
-    bubbles: true,
-    cancelable: true,
-  });
-
-  // Close any open Select/MenuTrigger popovers
-  document.querySelectorAll('[data-open], button[aria-expanded="true"]').forEach((el) => {
-    el.dispatchEvent(escapeEvent);
-  });
-
-  // Close any React Aria top-layer overlays
-  document.querySelectorAll("[data-react-aria-top-layer]").forEach((el) => {
-    el.dispatchEvent(escapeEvent);
-  });
-}
-
-/**
- * Hook for safe navigation that closes all modals first
- *
- * This hook ensures that all React Aria modals are properly closed
- * before navigation occurs, preventing the "removeChild" portal
- * cleanup errors that occur when modals are unmounted during navigation.
+ * Closes modals via normal React state updates (no flushSync) to avoid
+ * interfering with Waku's startTransition-based RSC routing. Then uses
+ * router.push for SPA navigation with a content-change check to detect
+ * and recover from failed navigations.
  *
  * @returns Navigation functions and state
- *
- * @example
- * ```tsx
- * function MyComponent() {
- *   const { isNavigating, navigate, goBack } = useSafeNavigation();
- *
- *   return (
- *     <Button onPress={goBack} isDisabled={isNavigating}>
- *       Back
- *     </Button>
- *   );
- * }
- * ```
  */
 export function useSafeNavigation(): SafeNavigationResult {
   const router = useRouter();
@@ -131,64 +108,69 @@ export function useSafeNavigation(): SafeNavigationResult {
   const [isNavigating, setIsNavigating] = useState(false);
 
   /**
-   * Close all modals and wait for DOM updates to complete
+   * Close all modals without blocking React's concurrent rendering.
+   * Uses normal state updates instead of flushSync to preserve
+   * Waku router's startTransition context.
    */
-  const closeModalsAndWait = useCallback((): Promise<void> => {
-    return new Promise((resolve) => {
-      // Use flushSync to force synchronous state updates
-      flushSync(() => {
-        // Close registered modals via modal registry
-        closeAllModals();
-        // Close uncontrolled popovers via DOM events
-        closeUncontrolledPopovers();
-        setIsNavigating(true);
-      });
-
-      // Wait for two animation frames to ensure DOM is updated
-      // First frame: React commits the changes
-      // Second frame: Browser paints the changes
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          resolve();
-        });
-      });
-    });
+  const closeModals = useCallback(() => {
+    closeAllModals();
+    closeUncontrolledPopovers();
+    setIsNavigating(true);
   }, [closeAllModals]);
+
+  /**
+   * Navigate using router.push with content-change verification.
+   * If the page content doesn't change within a timeout, falls back
+   * to window.location.href.
+   */
+  const navigateWithVerification = useCallback(
+    (path: string) => {
+      const currentContent = document.querySelector("main")?.innerHTML || "";
+
+      try {
+        router.push(path as `/${string}`);
+
+        // Notify navigation history tracker
+        requestAnimationFrame(() => {
+          window.dispatchEvent(new Event("rox-navigation"));
+        });
+
+        // Verify navigation actually updated the content
+        setTimeout(() => {
+          const newContent = document.querySelector("main")?.innerHTML || "";
+          const urlMatches = window.location.pathname === path.split("?")[0];
+
+          if (urlMatches && newContent === currentContent && currentContent !== "") {
+            // URL changed but content didn't — RSC fetch was skipped, fall back
+            window.location.href = path;
+          }
+        }, 500);
+      } catch {
+        window.location.href = path;
+      }
+    },
+    [router],
+  );
 
   /**
    * Navigate to a path after closing all modals
    */
   const navigate = useCallback(
-    async (path: string) => {
-      await closeModalsAndWait();
-
-      try {
-        // Cast to any to allow dynamic paths with Waku's router
-        router.push(path as `/${string}`);
-      } catch {
-        // Fallback to full page navigation if SPA navigation fails
-        window.location.href = path;
-      }
+    (path: string) => {
+      closeModals();
+      navigateWithVerification(path);
     },
-    [closeModalsAndWait, router],
+    [closeModals, navigateWithVerification],
   );
 
   /**
-   * Go back in history using full page navigation
-   *
-   * Go back to the previous page using SPA navigation.
+   * Go back to the previous page
    */
-  const goBack = useCallback(async () => {
-    await closeModalsAndWait();
-
+  const goBack = useCallback(() => {
+    closeModals();
     const previousPath = getPreviousPath("/timeline");
-
-    try {
-      router.push(previousPath as `/${string}`);
-    } catch {
-      window.location.href = previousPath;
-    }
-  }, [closeModalsAndWait, router]);
+    navigateWithVerification(previousPath);
+  }, [closeModals, navigateWithVerification]);
 
   return {
     isNavigating,


### PR DESCRIPTION
## Summary

プロフィール画面の Back ボタンで URL は変わるがコンテンツが更新されない問題の根本修正。

## Root Cause

2つの要因が重なっていた:

1. **AppProviders で `history.pushState` をモンキーパッチ** していたため、Waku の内部 RSC ルーティング (`startTransition` → `pushState` → RSC fetch) が干渉を受け、RSC 再取得がスキップされていた

2. **`useSafeNavigation` で `flushSync` を使用** していたため、React の concurrent rendering が中断され、その後の `requestAnimationFrame` 遅延で Waku ルーターの `startTransition` コンテキストが失われていた

## Changes

### A. `history.pushState` パッチ除去 (AppProviders.tsx)
- `pushState`/`replaceState` のモンキーパッチを完全除去
- 代わりにカスタムイベント `rox-navigation` で履歴を追跡
- `popstate` イベント + `rox-navigation` のみで動作

### B. `flushSync` + `rAF` 除去 (useSafeNavigation.ts)
- `flushSync` を通常の React 状態更新に変更
- `requestAnimationFrame` × 2 の遅延を除去
- `router.push` を直接呼び出し、Waku の `startTransition` を保持

### C. コンテンツ変更検証 (navigateWithVerification)
- `router.push` 後 500ms でコンテンツ変更を確認
- URL が変わったがコンテンツが同じ場合、`window.location.href` にフォールバック
- 完全な SPA 遷移が成功すればフォールバック不要

### D. SpaLink にイベント通知追加 (SpaLink.tsx)
- クリック時に `rox-navigation` カスタムイベントを発火
- ナビゲーション履歴の追跡を非侵襲的に実現

## Test plan

- [x] 型チェック通過
- [x] 全1012ユニットテスト通過
- [ ] 本番ビルドでプロフィール → Back → タイムラインが正しく表示されること
- [ ] SpaLink によるページ遷移が正常に動作すること
- [ ] ナビゲーション履歴が正しく記録されること

Closes #149

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * SPA のナビゲーション追跡を簡素化し、ブラウザの戻る/進むとカスタムイベントのみで経路を記録するように変更しました
  * リンククリック時にカスタムイベントを発火する処理を導入してナビゲーション検出を安定化しました
  * モーダル閉鎖と遷移処理を同期的に簡素化し、遷移完了検証と失敗時のフォールバックを追加しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->