### PR TITLE
chore: bump version to 2026.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rox",
-  "version": "2026.4.1-beta.3",
+  "version": "2026.4.1",
   "license": "AGPL-3.0-only",
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hono_rox",
-  "version": "1.5.1-beta.3",
+  "version": "1.5.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waku_rox",
-  "version": "1.5.1-beta.3",
+  "version": "1.5.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shared",
-  "version": "1.5.1-beta.3",
+  "version": "1.5.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump root version to `2026.4.1` (stable release)
- Bump package versions to `1.5.1`

## Test plan
- [x] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **チョア**
  * ルートおよび各パッケージのバージョン表記をベータ表記から正式版へ更新しました（ルートを 2026.4.1、バックエンド/フロントエンド/共有パッケージを 1.5.1 に変更）。これによりリリース表記が安定版になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->