### PR TITLE
Release v2026.4.1

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -18,7 +18,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -79,7 +79,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -87,7 +87,7 @@ jobs:
           bun-version: latest
 
       - name: Setup Node.js (for native module compatibility)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -110,7 +110,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "rox",
+      "dependencies": {
+        "waku": "^1.0.0-alpha.7",
+      },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
         "@types/bun": "^1.3.11",
@@ -16,7 +19,7 @@
     },
     "packages/backend": {
       "name": "hono_rox",
-      "version": "1.5.0-alpha.1",
+      "version": "1.5.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1025.0",
         "@hono/zod-validator": "^0.7.6",
@@ -55,7 +58,7 @@
     },
     "packages/frontend": {
       "name": "waku_rox",
-      "version": "1.5.0-alpha.1",
+      "version": "1.5.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -93,7 +96,7 @@
         "@storybook/react-vite": "^10.3.4",
         "@tailwindcss/vite": "^4.2.0",
         "@types/katex": "^0.16.8",
-        "@types/react": "^19.2.10",
+        "@types/react": "19.2.10",
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "^6.0.0",
         "babel-plugin-react-compiler": "1.0.0",
@@ -105,7 +108,7 @@
     },
     "packages/shared": {
       "name": "shared",
-      "version": "1.5.0-alpha.1",
+      "version": "1.5.0",
       "dependencies": {
         "vite-plus": "^0.1.16",
       },
@@ -114,10 +117,6 @@
         "typescript": "^5.9.3",
       },
     },
-  },
-  "overrides": {
-    "@vitejs/plugin-react": "^6.0.0",
-    "vite": "^8.0.0",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
@@ -322,7 +321,7 @@
 
     "@hexagon/base64": ["@hexagon/base64@1.1.28", "", {}, "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw=="],
 
-    "@hono/node-server": ["@hono/node-server@1.19.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw=="],
+    "@hono/node-server": ["@hono/node-server@1.19.13", "", { "peerDependencies": { "hono": "^4" } }, "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ=="],
 
     "@hono/zod-validator": ["@hono/zod-validator@0.7.6", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw=="],
 
@@ -1112,7 +1111,7 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
 
-    "@vitejs/plugin-rsc": ["@vitejs/plugin-rsc@0.5.21", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.5", "es-module-lexer": "^2.0.0", "estree-walker": "^3.0.3", "magic-string": "^0.30.21", "periscopic": "^4.0.2", "srvx": "^0.11.7", "strip-literal": "^3.1.0", "turbo-stream": "^3.1.0", "vitefu": "^1.1.1" }, "peerDependencies": { "react": "*", "react-dom": "*", "react-server-dom-webpack": "*", "vite": "*" }, "optionalPeers": ["react-server-dom-webpack"] }, "sha512-uNayLT8IKvWoznvQyfwKuGiEFV28o7lxUDnw/Av36VCuGpDFZnMmvVCwR37gTvnSmnpul9V0tdJqY3tBKEaDqw=="],
+    "@vitejs/plugin-rsc": ["@vitejs/plugin-rsc@0.5.23", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.13", "es-module-lexer": "^2.0.0", "estree-walker": "^3.0.3", "magic-string": "^0.30.21", "srvx": "^0.11.15", "strip-literal": "^3.1.0", "turbo-stream": "^3.2.0", "vitefu": "^1.1.3" }, "peerDependencies": { "react": "*", "react-dom": "*", "react-server-dom-webpack": "*", "vite": "*" }, "optionalPeers": ["react-server-dom-webpack"] }, "sha512-CV6kWPE4E241qDStwK3ErYjuZqW1i1xun3/P1wsm94RJoActLTrQsGzGsf75ioeVxEK0roPqLGhcV2WlSlPePQ=="],
 
     "@vitest/expect": ["@vitest/expect@4.1.3", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.3", "@vitest/utils": "4.1.3", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ=="],
 
@@ -1360,7 +1359,7 @@
 
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
-    "dotenv": ["dotenv@17.4.0", "", {}, "sha512-kCKF62fwtzwYm0IGBNjRUjtJgMfGapII+FslMHIjMR5KTnwEmBmWLDRSnc3XSNP8bNy34tekgQyDT0hr7pERRQ=="],
+    "dotenv": ["dotenv@17.4.1", "", {}, "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw=="],
 
     "drizzle-kit": ["drizzle-kit@0.31.10", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "tsx": "^4.21.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw=="],
 
@@ -1514,8 +1513,6 @@
 
     "is-property": ["is-property@1.0.2", "", {}, "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="],
 
-    "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
-
     "is-unicode-supported": ["is-unicode-supported@0.1.0", "", {}, "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="],
 
     "is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
@@ -1540,7 +1537,7 @@
 
     "js-sha256": ["js-sha256@0.10.1", "", {}, "sha512-5obBtsz9301ULlsgggLg542s/jqtddfOpV5KJc4hajc9JV8GeY2gZHSVpYBn4nWqAUTJ9v+xwtbJ1mIBgIH5Vw=="],
 
-    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+    "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
@@ -1721,8 +1718,6 @@
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
-
-    "periscopic": ["periscopic@4.0.2", "", { "dependencies": { "@types/estree": "*", "is-reference": "^3.0.2", "zimmerframe": "^1.0.0" } }, "sha512-sqpQDUy8vgB7ycLkendSKS6HnVz1Rneoc3Rc+ZBUCe2pbqlVuCC5vF52l0NJ1aiMg/r1qfYF9/myz8CZeI2rjA=="],
 
     "pg": ["pg@8.20.0", "", { "dependencies": { "pg-connection-string": "^2.12.0", "pg-pool": "^3.13.0", "pg-protocol": "^1.13.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.3.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA=="],
 
@@ -1990,7 +1985,7 @@
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
-    "turbo-stream": ["turbo-stream@3.1.0", "", {}, "sha512-tVI25WEXl4fckNEmrq70xU1XumxUwEx/FZD5AgEcV8ri7Wvrg2o7GEq8U7htrNx3CajciGm+kDyhRf5JB6t7/A=="],
+    "turbo-stream": ["turbo-stream@3.2.0", "", {}, "sha512-EK+bZ9UVrVh7JLslVFOV0GEMsociOqVOvEMTAd4ixMyffN5YNIEdLZWXUx5PJqDbTxSIBWw04HS9gCY4frYQDQ=="],
 
     "typedoc": ["typedoc@0.28.18", "", { "dependencies": { "@gerrit0/mini-shiki": "^3.23.0", "lunr": "^2.3.9", "markdown-it": "^14.1.1", "minimatch": "^10.2.4", "yaml": "^2.8.2" }, "peerDependencies": { "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x" }, "bin": { "typedoc": "bin/typedoc" } }, "sha512-NTWTUOFRQ9+SGKKTuWKUioUkjxNwtS3JDRPVKZAXGHZy2wCA8bdv2iJiyeePn0xkmK+TCCqZFT0X7+2+FLjngA=="],
 
@@ -2014,11 +2009,11 @@
 
     "vite-plus": ["vite-plus@0.1.15", "", { "dependencies": { "@oxc-project/types": "=0.122.0", "@voidzero-dev/vite-plus-core": "0.1.15", "@voidzero-dev/vite-plus-test": "0.1.15", "cac": "^7.0.0", "cross-spawn": "^7.0.5", "jsonc-parser": "^3.3.1", "oxfmt": "=0.43.0", "oxlint": "=1.58.0", "oxlint-tsgolint": "=0.18.1", "picocolors": "^1.1.1" }, "optionalDependencies": { "@voidzero-dev/vite-plus-darwin-arm64": "0.1.15", "@voidzero-dev/vite-plus-darwin-x64": "0.1.15", "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.1.15", "@voidzero-dev/vite-plus-linux-arm64-musl": "0.1.15", "@voidzero-dev/vite-plus-linux-x64-gnu": "0.1.15", "@voidzero-dev/vite-plus-linux-x64-musl": "0.1.15", "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.1.15", "@voidzero-dev/vite-plus-win32-x64-msvc": "0.1.15" }, "bin": { "vp": "bin/vp", "oxfmt": "bin/oxfmt", "oxlint": "bin/oxlint" } }, "sha512-PBUvTq4D4BJcuusCA3mrSQmXcGVdPX9CIPpS7Y6+T+LbDsrmAZ+ITl9FzuE6zXvpT6Nht9cpHtwOLJw7m3adog=="],
 
-    "vitefu": ["vitefu@1.1.1", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ=="],
+    "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 
     "vitest": ["vitest@4.1.3", "", { "dependencies": { "@vitest/expect": "4.1.3", "@vitest/mocker": "4.1.3", "@vitest/pretty-format": "4.1.3", "@vitest/runner": "4.1.3", "@vitest/snapshot": "4.1.3", "@vitest/spy": "4.1.3", "@vitest/utils": "4.1.3", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.3", "@vitest/browser-preview": "4.1.3", "@vitest/browser-webdriverio": "4.1.3", "@vitest/coverage-istanbul": "4.1.3", "@vitest/coverage-v8": "4.1.3", "@vitest/ui": "4.1.3", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw=="],
 
-    "waku": ["waku@1.0.0-alpha.6", "", { "dependencies": { "@hono/node-server": "^1.19.11", "@vitejs/plugin-react": "^5.1.0", "@vitejs/plugin-rsc": "^0.5.19", "dotenv": "^17.3.1", "hono": "^4.12.5", "magic-string": "^0.30.21", "picocolors": "^1.1.1", "rsc-html-stream": "^0.0.7", "vite": "^7.2.0" }, "peerDependencies": { "react": "~19.2.4", "react-dom": "~19.2.4", "react-server-dom-webpack": "~19.2.4" }, "bin": { "waku": "cli.js" } }, "sha512-Mp57otg27DMixncNvOaliIK5X9awtGIEtjuBoW9OgCPaghGvb4W4lFXmOTHseOWuZh3LynerfdqbvWOmEoIHUw=="],
+    "waku": ["waku@1.0.0-alpha.7", "", { "dependencies": { "@hono/node-server": "^1.19.13", "@vitejs/plugin-react": "^6.0.1", "@vitejs/plugin-rsc": "^0.5.23", "dotenv": "^17.4.1", "hono": "^4.12.12", "magic-string": "^0.30.21", "picocolors": "^1.1.1", "rsc-html-stream": "^0.0.7", "vite": "^8.0.0" }, "peerDependencies": { "react": "~19.2.4", "react-dom": "~19.2.4", "react-server-dom-webpack": "~19.2.4" }, "bin": { "waku": "cli.js" } }, "sha512-rFb8KBKDUc4nCdlHYUdjqDoI0wCAhVP5Bm3R4GdWu8WXzcwyZ3xQ9cK7KKD5yJHXOlMzciZlrLVI+lUDQ8nWsg=="],
 
     "waku_rox": ["waku_rox@workspace:packages/frontend"],
 
@@ -2060,8 +2055,6 @@
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
-    "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
-
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@aws-crypto/crc32/@aws-sdk/types": ["@aws-sdk/types@3.936.0", "", { "dependencies": { "@smithy/types": "^4.9.0", "tslib": "^2.6.2" } }, "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg=="],
@@ -2081,6 +2074,8 @@
     "@aws-crypto/util/@aws-sdk/types": ["@aws-sdk/types@3.936.0", "", { "dependencies": { "@smithy/types": "^4.9.0", "tslib": "^2.6.2" } }, "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg=="],
 
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -2136,7 +2131,7 @@
 
     "@types/pino/pino": ["pino@10.1.0", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-0zZC2ygfdqvqK8zJIr1e+wT1T/L+LF6qvqvbzEQ6tiMAoTqEVK9a1K3YRu8HEUvGEvNqZyPJTtb2sNIoTkB83w=="],
 
-    "@vitejs/plugin-rsc/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.5", "", {}, "sha512-RxlLX/DPoarZ9PtxVrQgZhPoor987YtKQqCo5zkjX+0S0yLJ7Vv515Wk6+xtTL67VONKJKxETWZwuZjss2idYw=="],
+    "@vitejs/plugin-rsc/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.13", "", {}, "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA=="],
 
     "@voidzero-dev/vite-plus-core/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -2208,8 +2203,6 @@
 
     "storybook/open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
-    "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
-
     "tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
@@ -2227,14 +2220,6 @@
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "vite/rolldown": ["rolldown@1.0.0-rc.13", "", { "dependencies": { "@oxc-project/types": "=0.123.0", "@rolldown/pluginutils": "1.0.0-rc.13" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.13", "@rolldown/binding-darwin-arm64": "1.0.0-rc.13", "@rolldown/binding-darwin-x64": "1.0.0-rc.13", "@rolldown/binding-freebsd-x64": "1.0.0-rc.13", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.13", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.13", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.13", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.13", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.13", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.13", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.13", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.13", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.13", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.13", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.13" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw=="],
-
-    "vitefu/vite": ["vite@8.0.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.12", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ=="],
-
-    "vitest/vite": ["vite@8.0.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.12", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ=="],
-
-    "waku/hono": ["hono@4.12.10", "", {}, "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w=="],
-
-    "waku/vite": ["vite@8.0.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.12", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ=="],
 
     "webpack/enhanced-resolve": ["enhanced-resolve@5.18.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww=="],
 
@@ -2499,12 +2484,6 @@
     "vite/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.13", "", { "os": "win32", "cpu": "x64" }, "sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ=="],
 
     "vite/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.13", "", {}, "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA=="],
-
-    "vitefu/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
-
-    "vitest/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
-
-    "waku/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rox",
-  "version": "2026.4.1-beta.1",
+  "version": "2026.4.1-beta.2",
   "license": "AGPL-3.0-only",
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rox",
-  "version": "2026.4.1-beta.3",
+  "version": "2026.4.1",
   "license": "AGPL-3.0-only",
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rox",
-  "version": "2026.4.0",
+  "version": "2026.4.1-beta.1",
   "license": "AGPL-3.0-only",
   "devDependencies": {
     "@playwright/test": "^1.59.1",
@@ -10,10 +10,6 @@
     "typedoc": "^0.28.18",
     "typescript": "^5.9.3",
     "vite-plus": "^0.1.15"
-  },
-  "overrides": {
-    "vite": "^8.0.0",
-    "@vitejs/plugin-react": "^6.0.0"
   },
   "description": "Lightweight ActivityPub server & client with Misskey API compatibility",
   "engines": {
@@ -55,5 +51,8 @@
   },
   "workspaces": [
     "packages/*"
-  ]
+  ],
+  "dependencies": {
+    "waku": "^1.0.0-alpha.7"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rox",
-  "version": "2026.4.1-beta.2",
+  "version": "2026.4.1-beta.3",
   "license": "AGPL-3.0-only",
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hono_rox",
-  "version": "1.5.1-beta.3",
+  "version": "1.5.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hono_rox",
-  "version": "1.5.1-beta.2",
+  "version": "1.5.1-beta.3",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hono_rox",
-  "version": "1.5.1-beta.1",
+  "version": "1.5.1-beta.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hono_rox",
-  "version": "1.5.0",
+  "version": "1.5.1-beta.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/backend/src/interfaces/IFileStorage.ts
+++ b/packages/backend/src/interfaces/IFileStorage.ts
@@ -1,7 +1,14 @@
+/**
+ * Metadata for a user-uploaded file.
+ */
 export interface FileMetadata {
+  /** Original file name */
   name: string;
+  /** MIME type of the file */
   type: string;
+  /** File size in bytes */
   size: number;
+  /** ID of the user who uploaded the file */
   userId: string;
 }
 
@@ -14,34 +21,45 @@ export interface EmojiFileMetadata {
   size: number;
 }
 
+/**
+ * Abstract file storage interface.
+ *
+ * Implementations handle saving, deleting, and resolving URLs for uploaded files.
+ * Supports both user-uploaded files and instance-owned emoji files.
+ */
 export interface IFileStorage {
   /**
-   * ファイルを保存
-   * @param file ファイルのBuffer
-   * @param metadata ファイルメタデータ
-   * @returns 保存されたファイルのパス（相対パスまたはキー）
+   * Save a file to storage.
+   *
+   * @param file - File contents as a Buffer
+   * @param metadata - File metadata including name, type, size, and owner
+   * @returns Relative path or key of the saved file
    */
   save(file: Buffer, metadata: FileMetadata): Promise<string>;
 
   /**
-   * Save emoji file to dedicated emoji directory
-   * Not associated with any user - instance-owned resource
-   * @param file File buffer
-   * @param metadata Emoji file metadata
+   * Save emoji file to dedicated emoji directory.
+   *
+   * Not associated with any user - instance-owned resource.
+   *
+   * @param file - File buffer
+   * @param metadata - Emoji file metadata
    * @returns Relative path of the saved file
    */
   saveEmoji(file: Buffer, metadata: EmojiFileMetadata): Promise<string>;
 
   /**
-   * ファイルを削除
-   * @param filePath ファイルパス
+   * Delete a file from storage.
+   *
+   * @param filePath - Relative path or key of the file to delete
    */
   delete(filePath: string): Promise<void>;
 
   /**
-   * ファイルの公開URLを取得
-   * @param filePath ファイルパス
-   * @returns 公開アクセス可能なURL
+   * Get the publicly accessible URL for a stored file.
+   *
+   * @param filePath - Relative path or key of the file
+   * @returns Publicly accessible URL
    */
   getUrl(filePath: string): string;
 }

--- a/packages/backend/src/interfaces/repositories/IUserRepository.ts
+++ b/packages/backend/src/interfaces/repositories/IUserRepository.ts
@@ -34,12 +34,18 @@ export interface SearchUsersOptions {
 
 export interface IUserRepository {
   /**
-   * ユーザーを作成
+   * Create a new user.
+   *
+   * @param user - User data excluding auto-generated timestamps
+   * @returns Created user record
    */
   create(user: Omit<User, "createdAt" | "updatedAt">): Promise<User>;
 
   /**
-   * IDでユーザーを取得
+   * Find a user by their ID.
+   *
+   * @param id - User ID
+   * @returns User if found, null otherwise
    */
   findById(id: string): Promise<User | null>;
 
@@ -52,14 +58,19 @@ export interface IUserRepository {
   findAll(options?: ListUsersOptions): Promise<User[]>;
 
   /**
-   * ユーザー名でユーザーを取得
-   * @param username ユーザー名
-   * @param host ホスト名（nullの場合はローカルユーザー）
+   * Find a user by username and host.
+   *
+   * @param username - Username to search for
+   * @param host - Host domain (null for local users)
+   * @returns User if found, null otherwise
    */
   findByUsername(username: string, host?: string | null): Promise<User | null>;
 
   /**
-   * メールアドレスでユーザーを取得
+   * Find a user by email address.
+   *
+   * @param email - Email address to search for
+   * @returns User if found, null otherwise
    */
   findByEmail(email: string): Promise<User | null>;
 
@@ -75,23 +86,33 @@ export interface IUserRepository {
   findByUri(uri: string): Promise<User | null>;
 
   /**
-   * ユーザー情報を更新
+   * Update a user's data.
+   *
+   * @param id - User ID
+   * @param data - Partial user data to update
+   * @returns Updated user record
    */
   update(id: string, data: Partial<Omit<User, "id" | "createdAt">>): Promise<User>;
 
   /**
-   * ユーザーを削除
+   * Delete a user by ID.
+   *
+   * @param id - User ID
    */
   delete(id: string): Promise<void>;
 
   /**
-   * ユーザー数を取得
-   * @param localOnly ローカルユーザーのみをカウントする場合はtrue
+   * Get the total number of users.
+   *
+   * @param localOnly - If true, count only local users
+   * @returns Total user count
    */
   count(localOnly?: boolean): Promise<number>;
 
   /**
-   * リモートユーザー数を取得
+   * Get the total number of remote users.
+   *
+   * @returns Remote user count
    */
   countRemote(): Promise<number>;
 

--- a/packages/backend/src/lib/logger.ts
+++ b/packages/backend/src/lib/logger.ts
@@ -70,13 +70,13 @@ function createLoggerConfig(config: LoggerConfig = {}): pino.LoggerOptions {
  */
 function createTransport(config: LoggerConfig = {}): pino.TransportSingleOptions | undefined {
   const isProduction = process.env.NODE_ENV === "production";
-  const pretty = config.pretty ?? !isProduction;
+  const pretty = config.pretty ?? true;
 
   if (pretty) {
     return {
       target: "pino-pretty",
       options: {
-        colorize: true,
+        colorize: !isProduction,
         translateTime: "SYS:standard",
         ignore: "pid,hostname,env",
       },

--- a/packages/backend/src/middleware/di.ts
+++ b/packages/backend/src/middleware/di.ts
@@ -3,14 +3,18 @@ import { getContainer, type AppContainer } from "../di/container.js";
 import type { PluginLoader } from "../plugins/loader.js";
 
 /**
- * DIミドルウェア
- * コンテナの内容をHonoのContextに注入
+ * Dependency injection middleware.
+ *
+ * Injects all DI container bindings into the Hono request context,
+ * making repositories, services, and adapters available to route handlers.
+ *
+ * @returns Hono middleware function
  */
 export function diMiddleware() {
   const container = getContainer();
 
   return async (c: Context, next: Next) => {
-    // コンテナの各プロパティをContextに設定
+    // Set each container property on the Hono context
     c.set("userRepository", container.userRepository);
     c.set("noteRepository", container.noteRepository);
     c.set("driveFileRepository", container.driveFileRepository);
@@ -61,7 +65,7 @@ export function diMiddleware() {
   };
 }
 
-// Hono Context型の拡張
+// Extend Hono's ContextVariableMap with DI container types
 declare module "hono" {
   interface ContextVariableMap extends AppContainer {
     container: AppContainer;

--- a/packages/backend/src/plugins/loader.ts
+++ b/packages/backend/src/plugins/loader.ts
@@ -178,8 +178,7 @@ export class PluginLoader {
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown error";
-      logger.error({ error: message }, "Failed to discover plugins directory");
-      // If plugins dir doesn't exist, that's okay - just no plugins
+      logger.debug({ error: message }, "Plugins directory not found, skipping");
     }
 
     return results;

--- a/packages/backend/src/routes/oauth.ts
+++ b/packages/backend/src/routes/oauth.ts
@@ -24,7 +24,10 @@ const STATE_COOKIE_NAME = "oauth_state";
 const STATE_COOKIE_MAX_AGE = 600; // 10 minutes
 
 /**
- * Get OAuth service instance
+ * Get OAuth service instance from the Hono context's DI container.
+ *
+ * @param c - Hono request context
+ * @returns Configured OAuthService instance
  */
 const getOAuthService = (c: Context): OAuthService => {
   const oauthAccountRepository = c.get("oauthAccountRepository");
@@ -34,7 +37,10 @@ const getOAuthService = (c: Context): OAuthService => {
 };
 
 /**
- * Validate OAuth provider parameter
+ * Validate that a string is a supported OAuth provider.
+ *
+ * @param provider - Provider name to validate
+ * @returns True if the provider is supported
  */
 const isValidProvider = (provider: string): provider is OAuthProvider => {
   return ["github", "google", "discord", "mastodon"].includes(provider);

--- a/packages/backend/src/services/NotificationStreamService.ts
+++ b/packages/backend/src/services/NotificationStreamService.ts
@@ -212,7 +212,17 @@ export class NotificationStreamService {
   }
 }
 
-// Export singleton getter
+/**
+ * Module-level singleton instance.
+ * Using a module-scoped variable avoids dual-instance issues
+ * when the module is loaded via different resolution paths.
+ */
+const globalKey = Symbol.for("rox.NotificationStreamService");
+const globalStore = globalThis as Record<symbol, NotificationStreamService>;
+
 export function getNotificationStreamService(): NotificationStreamService {
-  return NotificationStreamService.getInstance();
+  if (!globalStore[globalKey]) {
+    globalStore[globalKey] = NotificationStreamService.getInstance();
+  }
+  return globalStore[globalKey];
 }

--- a/packages/backend/src/services/NotificationStreamService.ts
+++ b/packages/backend/src/services/NotificationStreamService.ts
@@ -70,6 +70,8 @@ export class NotificationStreamService {
 
   /**
    * Get singleton instance
+   *
+   * @returns The shared NotificationStreamService instance
    */
   static getInstance(): NotificationStreamService {
     if (!NotificationStreamService.instance) {
@@ -151,6 +153,8 @@ export class NotificationStreamService {
 
   /**
    * Get total number of active connections
+   *
+   * @returns Sum of all user connection counts
    */
   getTotalConnections(): number {
     let total = 0;

--- a/packages/backend/src/services/NotificationStreamService.ts
+++ b/packages/backend/src/services/NotificationStreamService.ts
@@ -212,17 +212,7 @@ export class NotificationStreamService {
   }
 }
 
-/**
- * Module-level singleton instance.
- * Using a module-scoped variable avoids dual-instance issues
- * when the module is loaded via different resolution paths.
- */
-const globalKey = Symbol.for("rox.NotificationStreamService");
-const globalStore = globalThis as Record<symbol, NotificationStreamService>;
-
+// Export singleton getter
 export function getNotificationStreamService(): NotificationStreamService {
-  if (!globalStore[globalKey]) {
-    globalStore[globalKey] = NotificationStreamService.getInstance();
-  }
-  return globalStore[globalKey];
+  return NotificationStreamService.getInstance();
 }

--- a/packages/backend/src/services/NotificationStreamService.ts
+++ b/packages/backend/src/services/NotificationStreamService.ts
@@ -212,7 +212,11 @@ export class NotificationStreamService {
   }
 }
 
-// Export singleton getter
+/**
+ * Get the singleton NotificationStreamService instance.
+ *
+ * @returns The shared NotificationStreamService instance
+ */
 export function getNotificationStreamService(): NotificationStreamService {
   return NotificationStreamService.getInstance();
 }

--- a/packages/backend/src/tests/unit/NotificationService.test.ts
+++ b/packages/backend/src/tests/unit/NotificationService.test.ts
@@ -10,14 +10,6 @@ import type { INotificationRepository } from "../../interfaces/repositories/INot
 import type { IUserRepository } from "../../interfaces/repositories/IUserRepository.js";
 import type { Notification, NotificationType } from "../../db/schema/pg.js";
 
-// Mock the NotificationStreamService module
-mock.module("../../services/NotificationStreamService.js", () => ({
-  getNotificationStreamService: () => ({
-    pushNotification: () => {},
-    pushUnreadCount: () => {},
-  }),
-}));
-
 describe("NotificationService", () => {
   let notificationService: NotificationService;
   let mockNotificationRepository: INotificationRepository;

--- a/packages/backend/src/tests/unit/NotificationStreamService.test.ts
+++ b/packages/backend/src/tests/unit/NotificationStreamService.test.ts
@@ -14,7 +14,7 @@ import {
   NotificationStreamService,
   getNotificationStreamService,
   type NotificationEvent,
-} from "../../services/NotificationStreamService.js";
+} from "../../services/NotificationStreamService";
 
 describe("NotificationStreamService", () => {
   let service: NotificationStreamService;

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waku_rox",
-  "version": "1.5.1-beta.3",
+  "version": "1.5.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waku_rox",
-  "version": "1.5.1-beta.2",
+  "version": "1.5.1-beta.3",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waku_rox",
-  "version": "1.5.0",
+  "version": "1.5.1-beta.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waku_rox",
-  "version": "1.5.1-beta.1",
+  "version": "1.5.1-beta.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/frontend/src/components/ui/EmojiPicker.tsx
+++ b/packages/frontend/src/components/ui/EmojiPicker.tsx
@@ -40,7 +40,10 @@ import {
 const EMOJIS_PER_PAGE = 50;
 
 /**
- * Normalize category name for display, replacing sentinel values
+ * Normalize category name for display, replacing sentinel values.
+ *
+ * @param name - Raw category name (may be empty or "__uncategorized__")
+ * @returns Localized display name
  */
 function normalizeCategoryName(name: string): string {
   if (name === "__uncategorized__" || name === "") {

--- a/packages/frontend/src/components/ui/EmojiPicker.tsx
+++ b/packages/frontend/src/components/ui/EmojiPicker.tsx
@@ -126,6 +126,7 @@ function AccordionSection({
               {displayedEmojis.map((emoji, index) => (
                 <Button
                   variant="ghost"
+                  size={null}
                   key={`${emoji}-${index}`}
                   onPress={() => onEmojiClick(emoji)}
                   className="text-xl p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
@@ -206,6 +207,7 @@ function CustomAccordionSection({
               {displayedEmojis.map((emoji) => (
                 <Button
                   variant="ghost"
+                  size={null}
                   key={emoji.id}
                   onPress={() => onEmojiClick(emoji)}
                   className="p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
@@ -214,7 +216,7 @@ function CustomAccordionSection({
                   <img
                     src={getProxiedImageUrl(emoji.url) || ""}
                     alt={`:${emoji.name}:`}
-                    className="w-5 h-5 object-contain"
+                    className="w-7 h-7 object-contain"
                     loading="lazy"
                   />
                 </Button>
@@ -486,6 +488,7 @@ export function EmojiPicker({ onEmojiSelect, trigger, isDisabled }: EmojiPickerP
                               .map((emoji) => (
                                 <Button
                                   variant="ghost"
+                                  size={null}
                                   key={emoji.id}
                                   onPress={() => handleCustomEmojiClick(emoji)}
                                   className="p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
@@ -494,7 +497,7 @@ export function EmojiPicker({ onEmojiSelect, trigger, isDisabled }: EmojiPickerP
                                   <img
                                     src={getProxiedImageUrl(emoji.url) || ""}
                                     alt={`:${emoji.name}:`}
-                                    className="w-5 h-5 object-contain"
+                                    className="w-7 h-7 object-contain"
                                     loading="lazy"
                                   />
                                 </Button>
@@ -516,6 +519,7 @@ export function EmojiPicker({ onEmojiSelect, trigger, isDisabled }: EmojiPickerP
                               .map((emoji, index) => (
                                 <Button
                                   variant="ghost"
+                                  size={null}
                                   key={`${emoji}-${index}`}
                                   onPress={() => handleEmojiClick(emoji)}
                                   className="text-xl p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"

--- a/packages/frontend/src/components/ui/EmojiPicker.tsx
+++ b/packages/frontend/src/components/ui/EmojiPicker.tsx
@@ -68,6 +68,28 @@ export interface EmojiPickerProps {
 }
 
 /**
+ * Sentinel element that triggers a callback when it becomes visible
+ */
+function LoadMoreSentinel({ onLoadMore }: { onLoadMore: () => void }) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) onLoadMore();
+      },
+      { threshold: 0 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [onLoadMore]);
+
+  return <div ref={ref} className="h-1" />;
+}
+
+/**
  * Props for the accordion section component
  */
 interface AccordionSectionProps {
@@ -85,6 +107,8 @@ interface AccordionSectionProps {
   visibleCount: number;
   /** Whether there are more emojis */
   hasMore: boolean;
+  /** Callback to load more emojis */
+  onLoadMore?: () => void;
 }
 
 /**
@@ -98,6 +122,7 @@ function AccordionSection({
   onEmojiClick,
   visibleCount,
   hasMore,
+  onLoadMore,
 }: AccordionSectionProps) {
   const displayedEmojis = emojis.slice(0, visibleCount);
 
@@ -136,11 +161,7 @@ function AccordionSection({
                 </Button>
               ))}
             </div>
-            {hasMore && (
-              <div className="text-center py-1.5 text-xs text-gray-400">
-                {displayedEmojis.length}/{emojis.length}
-              </div>
-            )}
+            {hasMore && onLoadMore && <LoadMoreSentinel onLoadMore={onLoadMore} />}
           </DisclosurePanel>
         </>
       )}
@@ -166,6 +187,8 @@ interface CustomAccordionSectionProps {
   visibleCount: number;
   /** Whether there are more emojis */
   hasMore: boolean;
+  /** Callback to load more emojis */
+  onLoadMore?: () => void;
 }
 
 /**
@@ -179,6 +202,7 @@ function CustomAccordionSection({
   onEmojiClick,
   visibleCount,
   hasMore,
+  onLoadMore,
 }: CustomAccordionSectionProps) {
   const displayedEmojis = emojis.slice(0, visibleCount);
 
@@ -222,11 +246,7 @@ function CustomAccordionSection({
                 </Button>
               ))}
             </div>
-            {hasMore && (
-              <div className="text-center py-1.5 text-xs text-gray-400">
-                {displayedEmojis.length}/{emojis.length}
-              </div>
-            )}
+            {hasMore && onLoadMore && <LoadMoreSentinel onLoadMore={onLoadMore} />}
           </DisclosurePanel>
         </>
       )}
@@ -565,6 +585,7 @@ export function EmojiPicker({ onEmojiSelect, trigger, isDisabled }: EmojiPickerP
                           onEmojiClick={handleCustomEmojiClick}
                           visibleCount={getVisibleCount("custom")}
                           hasMore={getVisibleCount("custom") < customEmojis.length}
+                          onLoadMore={() => loadMore("custom", customEmojis.length)}
                         />
                       )}
 
@@ -595,6 +616,7 @@ export function EmojiPicker({ onEmojiSelect, trigger, isDisabled }: EmojiPickerP
                               onEmojiClick={handleCustomEmojiClick}
                               visibleCount={getVisibleCount(categoryKey)}
                               hasMore={getVisibleCount(categoryKey) < catEmojis.length}
+                              onLoadMore={() => loadMore(categoryKey, catEmojis.length)}
                             />
                           );
                         })}
@@ -609,6 +631,7 @@ export function EmojiPicker({ onEmojiSelect, trigger, isDisabled }: EmojiPickerP
                           onEmojiClick={handleEmojiClick}
                           visibleCount={getVisibleCount("recent")}
                           hasMore={getVisibleCount("recent") < recentEmojis.length}
+                          onLoadMore={() => loadMore("recent", recentEmojis.length)}
                         />
                       )}
 
@@ -626,6 +649,9 @@ export function EmojiPicker({ onEmojiSelect, trigger, isDisabled }: EmojiPickerP
                             visibleCount={getVisibleCount(category)}
                             hasMore={
                               getVisibleCount(category) < EMOJI_CATEGORIES[category].emojis.length
+                            }
+                            onLoadMore={() =>
+                              loadMore(category, EMOJI_CATEGORIES[category].emojis.length)
                             }
                           />
                         ))}

--- a/packages/frontend/src/components/ui/EmojiPicker.tsx
+++ b/packages/frontend/src/components/ui/EmojiPicker.tsx
@@ -68,7 +68,10 @@ export interface EmojiPickerProps {
 }
 
 /**
- * Sentinel element that triggers a callback when it becomes visible
+ * Sentinel element that triggers a callback when it becomes visible.
+ * Uses IntersectionObserver to detect when the element enters the viewport.
+ *
+ * @param onLoadMore - Callback invoked when the sentinel becomes visible
  */
 function LoadMoreSentinel({ onLoadMore }: { onLoadMore: () => void }) {
   const ref = useRef<HTMLDivElement>(null);

--- a/packages/frontend/src/components/ui/Spinner.tsx
+++ b/packages/frontend/src/components/ui/Spinner.tsx
@@ -42,7 +42,9 @@ export function Spinner({ size = "md", variant = "primary", className = "" }: Sp
 }
 
 /**
- * Loading spinner with text label
+ * Loading spinner with text label.
+ *
+ * @returns A flex container with a spinner and a text label
  */
 export function SpinnerWithLabel({
   label,

--- a/packages/frontend/src/pages/[username]/index.tsx
+++ b/packages/frontend/src/pages/[username]/index.tsx
@@ -55,8 +55,8 @@ export default async function UserPage({ username: usernameParam }: PageProps<"/
     user = await import("../../lib/api/users").then((m) =>
       m.usersApi.getByUsername(username, host),
     );
-  } catch (error) {
-    console.error("[SSR] Failed to fetch user for OGP:", error);
+  } catch {
+    // User not found or fetch failed — continue with fallback OGP tags
   }
 
   // Generate OGP meta tags if user data is available

--- a/packages/frontend/src/pages/notes/[noteId].tsx
+++ b/packages/frontend/src/pages/notes/[noteId].tsx
@@ -30,9 +30,8 @@ export default async function NoteDetailPage({ noteId }: PageProps<"/notes/[note
     if (note?.user?.id) {
       user = await usersApi.getById(note.user.id);
     }
-  } catch (error) {
-    console.error("[SSR] Failed to fetch note for OGP:", error);
-    // Continue without fetched data - OGP will use fallback values
+  } catch {
+    // Note not found or fetch failed — continue with fallback OGP tags
   }
 
   // Generate OGP meta tags if note data is available

--- a/packages/frontend/waku.config.ts
+++ b/packages/frontend/waku.config.ts
@@ -6,8 +6,7 @@ import { getSharedVitePlugins } from "./vite-plugins";
  * Waku configuration
  * Configures Vite settings for Tailwind CSS v4 (via Vite plugin) and Lingui integration
  *
- * Note: @vitejs/plugin-react v6 (Vite 8) removed the `babel` option.
- * Lingui macro transformation is now handled via @rolldown/plugin-babel.
+ * Lingui macro transformation is handled via @rolldown/plugin-babel.
  */
 export default defineConfig({
   /** Vite configuration for all environments */

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shared",
-  "version": "1.5.1-beta.1",
+  "version": "1.5.1-beta.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shared",
-  "version": "1.5.1-beta.2",
+  "version": "1.5.1-beta.3",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shared",
-  "version": "1.5.1-beta.3",
+  "version": "1.5.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shared",
-  "version": "1.5.0",
+  "version": "1.5.1-beta.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/shared/src/constants/validation.ts
+++ b/packages/shared/src/constants/validation.ts
@@ -11,8 +11,11 @@
 // Username Validation
 // ============================================
 
+/** Minimum allowed username length. */
 export const USERNAME_MIN_LENGTH = 3;
+/** Maximum allowed username length. */
 export const USERNAME_MAX_LENGTH = 20;
+/** Allowed characters in a username: alphanumeric and underscore. */
 export const USERNAME_PATTERN = /^[a-zA-Z0-9_]+$/;
 
 /**
@@ -100,38 +103,48 @@ export function isDefaultReservedUsername(username: string): boolean {
 // Password Validation
 // ============================================
 
+/** Minimum allowed password length. */
 export const PASSWORD_MIN_LENGTH = 8;
 
 // ============================================
 // Note Validation
 // ============================================
 
+/** Maximum character length for note text. */
 export const NOTE_TEXT_MAX_LENGTH = 3000;
+/** Maximum character length for a content warning. */
 export const NOTE_CW_MAX_LENGTH = 100;
+/** Maximum number of files attachable to a single note. */
 export const NOTE_MAX_FILES = 4;
 
 // ============================================
 // User Profile Validation
 // ============================================
 
+/** Maximum character length for a user's display name. */
 export const DISPLAY_NAME_MAX_LENGTH = 100;
+/** Maximum character length for a user's bio. */
 export const BIO_MAX_LENGTH = 500;
 
 // ============================================
 // Reaction Validation
 // ============================================
 
+/** Maximum character length for a reaction string. */
 export const REACTION_MAX_LENGTH = 50;
 
 // ============================================
 // File Validation
 // ============================================
 
+/** Maximum character length for a file comment (alt text). */
 export const FILE_COMMENT_MAX_LENGTH = 512;
 
 // ============================================
 // Pagination Defaults
 // ============================================
 
+/** Default number of items per page in paginated queries. */
 export const DEFAULT_PAGE_LIMIT = 20;
+/** Maximum allowed items per page in paginated queries. */
 export const MAX_PAGE_LIMIT = 100;

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -1,7 +1,10 @@
+/** Note visibility level controlling who can see the content. */
 export type Visibility = "public" | "home" | "followers" | "specified";
 
+/** Unique identifier represented as a string. */
 export type ID = string;
 
+/** Common timestamp fields shared across entities. */
 export interface Timestamps {
   createdAt: Date;
   updatedAt: Date;

--- a/packages/shared/src/types/file.ts
+++ b/packages/shared/src/types/file.ts
@@ -1,9 +1,10 @@
 import type { ID, Timestamps } from "./common.js";
 
+/** Origin of a file: user-uploaded or system-acquired. */
 export type FileSource = "user" | "system";
 
 /**
- * Drive folder for organizing files
+ * Drive folder for organizing files.
  */
 export interface DriveFolder extends Timestamps {
   id: ID;
@@ -12,6 +13,7 @@ export interface DriveFolder extends Timestamps {
   name: string;
 }
 
+/** A file stored in the user's drive with metadata and storage details. */
 export interface DriveFile extends Timestamps {
   id: ID;
   userId: ID;
@@ -29,6 +31,7 @@ export interface DriveFile extends Timestamps {
   source: FileSource; // "user" for user uploads, "system" for system-acquired files
 }
 
+/** Metadata provided when uploading a file to storage. */
 export interface FileMetadata {
   name: string;
   type: string;

--- a/packages/shared/src/types/note.ts
+++ b/packages/shared/src/types/note.ts
@@ -1,5 +1,6 @@
 import type { ID, Timestamps, Visibility } from "./common.js";
 
+/** A note (post) created by a user, supporting content warnings, visibility, and soft deletion. */
 export interface Note extends Timestamps {
   id: ID;
   userId: ID;
@@ -24,6 +25,7 @@ export interface Note extends Timestamps {
   deletionReason: string | null;
 }
 
+/** A note with eagerly loaded relations such as author, files, and reactions. */
 export interface NoteWithRelations extends Note {
   user?: {
     id: ID;

--- a/packages/shared/src/types/reaction.ts
+++ b/packages/shared/src/types/reaction.ts
@@ -1,5 +1,6 @@
 import type { ID, Timestamps } from "./common.js";
 
+/** A reaction (emoji or custom emoji) attached to a note by a user. */
 export interface Reaction extends Timestamps {
   id: ID;
   userId: ID;

--- a/packages/shared/src/types/session.ts
+++ b/packages/shared/src/types/session.ts
@@ -1,5 +1,6 @@
 import type { ID, Timestamps } from "./common.js";
 
+/** An authenticated user session with expiry and client metadata. */
 export interface Session extends Timestamps {
   id: ID;
   userId: ID;

--- a/packages/shared/src/types/uiSettings.ts
+++ b/packages/shared/src/types/uiSettings.ts
@@ -4,11 +4,16 @@
  * Shared type definitions for user UI customization options.
  */
 
+/** Available font size options for the UI. */
 export type FontSize = "small" | "medium" | "large" | "xlarge";
+/** Line height density options. */
 export type LineHeight = "compact" | "normal" | "relaxed";
+/** Content area width options. */
 export type ContentWidth = "narrow" | "normal" | "wide";
+/** Color theme preference. */
 export type Theme = "light" | "dark" | "system";
 
+/** User-configurable UI display preferences. */
 export interface UISettings {
   fontSize?: FontSize;
   lineHeight?: LineHeight;

--- a/packages/shared/src/types/user.ts
+++ b/packages/shared/src/types/user.ts
@@ -9,6 +9,7 @@ export interface ProfileEmoji {
   url: string;
 }
 
+/** A local or remote user account with authentication, ActivityPub, and profile fields. */
 export interface User extends Timestamps {
   id: ID;
   username: string;
@@ -56,6 +57,7 @@ export interface User extends Timestamps {
   followingCount: number;
 }
 
+/** Public-facing user profile with a subset of fields safe for display. */
 export interface UserProfile {
   id: ID;
   username: string;
@@ -67,6 +69,7 @@ export interface UserProfile {
   createdAt: Date;
 }
 
+/** A follow relationship between two users. */
 export interface Follow extends Timestamps {
   id: ID;
   followerId: ID;


### PR DESCRIPTION
## Summary
- Upgrade waku to 1.0.0-alpha.7 (official Vite 8 support)
- Remove vite/plugin-react overrides (no longer needed)
- Fix custom emoji size in emoji picker (cva default size override)
- Add IntersectionObserver-based infinite scroll for emoji categories
- Fix NotificationStreamService test mock leakage on Bun 1.3.12
- Upgrade GitHub Actions (checkout v6, setup-node v6)
- Enable pino-pretty log formatting in production
- Suppress noisy SSR error logs for 404 responses
- Downgrade missing plugins directory log from ERROR to DEBUG
- Add TSDoc across shared types, backend interfaces, and frontend components

## Test plan
- [x] CI passes on all jobs (Unit Tests, SQLite, Lint, Type Check, Build)
- [x] Production tested on beta versions