### PR TITLE
chore: add git workflow rules and dev sync automation

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,41 @@
+# Git Workflow Rules
+
+## Branch Strategy
+
+```
+feature/* ──PR──> dev ──PR──> main (release only)
+                                │
+                                └──> dev (auto-synced by GitHub Actions)
+```
+
+## Rules
+
+### 1. Always use feature branches
+- **Never commit directly to `dev` or `main`**
+- Create a feature branch from `dev` for every change (e.g., `fix/emoji-size`, `chore/bump-version`, `feat/new-feature`)
+- Branch naming: `{type}/{short-description}` (types: feat, fix, chore, docs, refactor)
+
+### 2. PRs always target `dev`
+- All feature branch PRs merge into `dev`
+- Wait for CI to pass before merging
+- Delete the feature branch after merge
+
+### 3. Releases merge `dev` into `main`
+- Only create a `dev` → `main` PR for stable version releases
+- The PR should contain **all commits since the last stable release** as a single merge
+- PR title: `Release vX.X.X`
+- PR body: Summary of all changes (features, fixes, docs, maintenance)
+- After merging to main:
+  - The `auto-tag` workflow automatically creates a Git tag and GitHub Release with categorized changelog
+  - The `sync-dev` workflow automatically fast-forwards `dev` to match `main`
+
+### 4. Version bumps
+- Beta/prerelease versions: bump on `dev` via feature branch PR
+- Stable versions: bump in the same feature branch as the release PR to `dev`, then merge `dev` → `main`
+
+## Summary of automation
+| Event | Automated by |
+|-------|-------------|
+| Tag + Release creation on main | `auto-tag.yml` |
+| dev sync after main merge | `sync-dev.yml` |
+| CI checks on PRs | `ci.yml` |

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -80,9 +80,22 @@ jobs:
         id: prev_tag
         run: |
           CURRENT_TAG="v${{ needs.auto-tag.outputs.version }}"
-          PREV_TAG=$(git describe --tags --abbrev=0 "${CURRENT_TAG}^" 2>/dev/null || echo "")
-          echo "prev_tag=$PREV_TAG" >> $GITHUB_OUTPUT
-          echo "Previous tag: $PREV_TAG"
+          VERSION="${{ needs.auto-tag.outputs.version }}"
+
+          # For stable releases, find the previous stable tag (skip prereleases)
+          # For prereleases, find the previous tag of any kind
+          if [[ "$VERSION" != *"-"* ]]; then
+            # Stable release: find previous stable tag
+            PREV_TAG=$(git tag --sort=-v:refname | grep -v '\-alpha\|\-beta\|\-rc' | grep -v "^${CURRENT_TAG}$" | head -1)
+            echo "Stable release: comparing against previous stable tag"
+          else
+            # Prerelease: find the immediately previous tag
+            PREV_TAG=$(git describe --tags --abbrev=0 "${CURRENT_TAG}^" 2>/dev/null || echo "")
+            echo "Prerelease: comparing against previous tag"
+          fi
+
+          echo "prev_tag=${PREV_TAG:-}" >> $GITHUB_OUTPUT
+          echo "Previous tag: ${PREV_TAG:-none}"
 
       - name: Extract package versions
         id: pkg_versions

--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -1,0 +1,26 @@
+name: Sync dev with main
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Sync dev branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout dev
+          git merge main --ff-only
+          git push origin dev

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,7 @@ For detailed guidelines, see `.claude/rules/`:
 | `devcontainer.md` | DevContainer setup |
 | `mcp-servers.md` | MCP server usage |
 | `discord-logger.md` | Discord conversation logging |
+| `git-workflow.md` | Git branching and release workflow |
 
 ## Historical Documentation
 


### PR DESCRIPTION
## Summary
- Add `.claude/rules/git-workflow.md` — branch strategy and release workflow rules
- Add `sync-dev.yml` — GitHub Actions workflow to auto fast-forward dev after main merge
- Update `CLAUDE.md` rules table

## Workflow
```
feature/* ──PR──> dev ──PR──> main (release only)
                                │
                                └──> dev (auto-synced)
```

## Test plan
- [ ] CI passes
- [ ] Verify sync-dev workflow triggers on next main merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * Git ワークフローの定義を追加

* **Chores**
  * 開発ブランチとメインブランチの自動同期機能を導入

<!-- end of auto-generated comment: release notes by coderabbit.ai -->