### PR TITLE
chore: auto-close issues when PRs merge to dev

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -1,0 +1,53 @@
+name: Auto-close issues on dev merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [dev]
+
+permissions:
+  issues: write
+
+jobs:
+  close-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close referenced issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const prNumber = context.payload.pull_request.number;
+
+            // Match "Closes #N", "Fixes #N", "Resolves #N" (case-insensitive)
+            const pattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+            const issueNumbers = new Set();
+
+            let match;
+            while ((match = pattern.exec(body)) !== null) {
+              issueNumbers.add(parseInt(match[1], 10));
+            }
+
+            for (const issueNumber of issueNumbers) {
+              try {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  body: `Closed by #${prNumber} (merged to dev).`,
+                });
+
+                console.log(`Closed issue #${issueNumber}`);
+              } catch (error) {
+                console.log(`Failed to close issue #${issueNumber}: ${error.message}`);
+              }
+            }


### PR DESCRIPTION
Closes #160

## Summary
Add `close-issues.yml` workflow that triggers when PRs are merged to `dev`.
Parses `Closes #N` / `Fixes #N` / `Resolves #N` from PR bodies and
auto-closes the referenced issues with a comment.

## How it works
- Triggers on `pull_request.closed` event for `dev` branch
- Only runs if the PR was actually merged (not just closed)
- Uses `actions/github-script` to parse and close issues via GitHub API

## Test plan
- [ ] This PR itself will test the workflow — issue #160 should auto-close on merge