### PR TITLE
chore: harden CI/CD against supply-chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,93 @@
+# Dependabot configuration
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # GitHub Actions versions
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: scope
+
+  # npm dependencies - root
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: scope
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # npm dependencies - backend
+  - package-ecosystem: npm
+    directory: "/packages/backend"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 10
+    labels:
+      - backend
+    commit-message:
+      prefix: "chore"
+      include: scope
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # npm dependencies - frontend
+  - package-ecosystem: npm
+    directory: "/packages/frontend"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 10
+    labels:
+      - frontend
+    commit-message:
+      prefix: "chore"
+      include: scope
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # npm dependencies - shared
+  - package-ecosystem: npm
+    directory: "/packages/shared"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: scope
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -8,17 +8,19 @@ on:
       - "package.json"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   auto-tag:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       tag_created: ${{ steps.create_tag.outputs.created }}
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
         with:
           fetch-depth: 0
 
@@ -70,9 +72,11 @@ jobs:
     needs: [auto-tag, call-ci]
     if: needs.auto-tag.outputs.tag_created == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
         with:
           fetch-depth: 0
 
@@ -254,7 +258,7 @@ jobs:
           cat CHANGELOG.md
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: v${{ needs.auto-tag.outputs.version }}
           name: "Rox ${{ needs.auto-tag.outputs.version }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,12 @@ on:
     branches-ignore:
       - 'dependabot/**'
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   workflow_call:
+
+# Default permissions: read-only. Each job opts in to more when needed.
+permissions:
+  contents: read
 
 env:
   # Default environment for tests (no real DB needed for unit tests)
@@ -16,23 +20,39 @@ env:
   LOCAL_STORAGE_PATH: ./uploads
   URL: http://localhost:3000
   NODE_ENV: test
+  # Pinned tool versions. Bump explicitly; do not use "latest".
+  BUN_VERSION: "1.3.14"
 
 jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    # Only meaningful on PRs (compares base..head).
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+      - name: Review dependencies
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure
+
   lint-and-typecheck:
     name: Lint & Type Check
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Lint
         run: bun run lint
@@ -53,15 +73,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run unit tests
         run: bun test src/tests/unit/
@@ -79,20 +99,20 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Setup Node.js (for native module compatibility)
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run SQLite integration tests
         run: bunx vitest run src/tests/node/sqlite-repositories.test.ts
@@ -110,15 +130,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Build backend
         run: bun run build

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close referenced issues
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.0.1
         with:
           script: |
             const body = context.payload.pull_request.body || '';

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,10 @@ on:
       - 'README.md'
   workflow_dispatch:  # Allow manual trigger
 
+env:
+  # Pinned tool versions. Bump explicitly; do not use "latest".
+  BUN_VERSION: "1.3.14"
+
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
@@ -47,7 +51,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: "1.3.14"
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,24 +42,24 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: "1.3.14"
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Generate TypeDoc documentation
         run: npx typedoc
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: ./docs/api
 
@@ -74,4 +74,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ on:
         default: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   # 1. Run CI workflow first (unless skipped)
@@ -39,9 +39,11 @@ jobs:
     needs: call-ci
     if: ${{ always() && (needs.call-ci.result == 'success' || needs.call-ci.result == 'skipped') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
         with:
           fetch-depth: 0
 
@@ -256,7 +258,7 @@ jobs:
           cat CHANGELOG.md
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: "Rox ${{ steps.version.outputs.version }}"

--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Closes #162

## Summary

直近で連続している supply-chain 攻撃（`tj-actions/changed-files` の compromise、`shai-hulud` npm worm、`nx`/`chalk`/`debug` の悪性版配布など）に対する CI/CD 側の防御を導入。

## Changes

### `.github/workflows/*.yml`
- **すべての Actions を commit SHA に固定**（コメントで semver を併記）
  - `oven-sh/setup-bun` → `0c5077e5...` (v2.2.0)
  - `softprops/action-gh-release` → `3bb12739...` (v2.6.2)
  - `actions/checkout` → `de0fac2e...` (v6.0.0)
  - 他 `setup-node`/`github-script`/`configure-pages`/`upload-pages-artifact`/`deploy-pages` も SHA 固定
- **Bun を 1.3.14 に固定**（`latest` 廃止）
- **Node を 24 (LTS) に bump**（旧 20、2026-04 で EOL）
- **`bun install --frozen-lockfile`** を CI の全 install step で強制
- **`GITHUB_TOKEN` 既定権限を `contents: read`** に変更し、release/tag job のみ `contents: write` を opt-in
- **Dependency Review job** を PR チェックに追加（`fail-on-severity: high`）
- CI を `pull_request: [main, dev]` 両方でトリガーするよう拡張

### `.github/dependabot.yml`（新規）
- `github-actions` ecosystem を週次更新（pinned SHA の追従用）
- `npm` ecosystem を root / backend / frontend / shared の 4 ディレクトリで週次更新
- minor/patch は単一 PR にグループ化、major は個別 PR

## Out of scope (next phase)

- Sigstore/cosign 署名と build provenance attestation
- 本番ホストの egress allowlist

## Test plan

- [ ] CI が緑になる（自身がこの PR で更新したワークフロー自体で検証される）
- [ ] Dependency Review job が PR で走る（この PR でも実行されることを確認）
- [ ] frozen-lockfile が走り、想定外の lockfile 差分があれば fail することを確認

## Risk

- `bun-version: latest` から固定したので、Bun の新バージョンが出るたび手動 bump が必要（Dependabot は Bun runtime には対応していないため、`BUN_VERSION` 環境変数を手動更新で運用）
- 全 Actions SHA 固定後、`v6`/`v2` などの tag rewrite による「便利な自動更新」は無くなる代わりに Dependabot PR ベース運用になる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * GitHub Actions ワークフローとアクション依存関係をセキュリティと安定性向上のため更新しました。
  * Dependabot 自動更新機能を設定し、定期的な依存関係チェックを有効化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Love-Rox/rox/pull/164)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->