### PR TITLE
chore: phase 2 supply-chain hardening (SBOM + provenance)

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -74,6 +74,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write       # for sigstore signing via GitHub OIDC
+      attestations: write   # for actions/attest-build-provenance
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
@@ -257,6 +259,21 @@ jobs:
 
           cat CHANGELOG.md
 
+      - name: Generate SBOM (SPDX-JSON)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: spdx-json
+          artifact-name: rox-${{ needs.auto-tag.outputs.version }}.spdx.json
+          output-file: rox-${{ needs.auto-tag.outputs.version }}.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest SBOM provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: rox-${{ needs.auto-tag.outputs.version }}.spdx.json
+
       - name: Create Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
@@ -265,5 +282,7 @@ jobs:
           body_path: CHANGELOG.md
           prerelease: ${{ steps.check.outputs.is_prerelease }}
           draft: false
+          files: |
+            rox-${{ needs.auto-tag.outputs.version }}.spdx.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write       # for sigstore signing via GitHub OIDC
+      attestations: write   # for actions/attest-build-provenance
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
@@ -257,6 +259,21 @@ jobs:
 
           cat CHANGELOG.md
 
+      - name: Generate SBOM (SPDX-JSON)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: spdx-json
+          artifact-name: rox-${{ steps.version.outputs.version }}.spdx.json
+          output-file: rox-${{ steps.version.outputs.version }}.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest SBOM provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: rox-${{ steps.version.outputs.version }}.spdx.json
+
       - name: Create Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
@@ -266,5 +283,7 @@ jobs:
           prerelease: ${{ steps.check.outputs.is_prerelease }}
           draft: false
           generate_release_notes: false
+          files: |
+            rox-${{ steps.version.outputs.version }}.spdx.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -94,5 +94,9 @@ docker/certs/*-key.pem
 # cipher data
 cipherdata/
 cipher.yml
+
 # Jujutsu
 .jj/
+
+# Playwright MCP snapshots / screenshots (test artifacts)
+.playwright-mcp/


### PR DESCRIPTION
Closes #168

## Summary

Phase 1（#164）の続編。リリース成果物の **透明性** と **検証可能性** を高める。

- **SBOM (SPDX-JSON)** をリリース時に自動生成して GitHub Release に添付
- **Build provenance attestation** を Sigstore (GitHub OIDC) で付与 → 利用者が \`gh attestation verify\` で出自を検証可能
- 副次: \`.playwright-mcp/\` を gitignore に追加（テスト成果物の混入防止）

## Changes

### `.github/workflows/auto-tag.yml` & `release.yml`

両ワークフローの \`create-release\` job に以下を追加：

1. **SBOM 生成** (\`anchore/sbom-action\` @ v0.24.0, SHA pinned)
   - リポジトリ全体を Syft でスキャン
   - SPDX-JSON 形式で \`rox-<version>.spdx.json\` を出力

2. **Provenance attestation** (\`actions/attest-build-provenance\` @ v4.1.0, SHA pinned)
   - Sigstore 経由（GitHub OIDC、keyless 署名）
   - SBOM ファイルを subject として attestation 作成
   - GitHub の Attestations タブに記録

3. **Release attach**
   - \`softprops/action-gh-release\` の \`files:\` に SBOM を追加

### Permissions opt-in（最小権限維持）

\`create-release\` job のみに以下を付与：
- \`id-token: write\` (Sigstore OIDC 用)
- \`attestations: write\` (GitHub attestation API 用)

他の job はデフォルトの \`contents: read\` のまま。

### `.gitignore`
- \`.playwright-mcp/\` を追加（Playwright MCP のスナップショット・スクリーンショット）

## Verification by users

リリース後、利用者は以下で出自を検証可能：

\`\`\`bash
# SBOM ダウンロード後
gh attestation verify rox-2026.5.0.spdx.json --repo Love-Rox/rox
\`\`\`

成功すれば「この SBOM は Love-Rox/rox の <commit-sha> から作られた」ことを暗号学的に証明できる。

## Test plan

- [ ] CI が緑になる（変更は workflow YAML のみで、テスト実行に影響しない）
- [ ] 次のリリース時（タグ push or 手動 release）に SBOM が生成され Release に添付されることを確認
- [ ] Attestation が GitHub の Actions > Attestations に表示されることを確認
- [ ] \`gh attestation verify\` で検証成功

## Out of scope

- 過去リリースへの遡及 SBOM 生成 → 不要
- Docker image push to GHCR + cosign → 利用者がレジストリ pull する運用が無いため