### PR TITLE
chore: bump version to 2026.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rox",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "license": "AGPL-3.0-only",
   "devDependencies": {
     "@playwright/test": "^1.60.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hono_rox",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waku_rox",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shared",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
## Summary

5月の最初の安定版リリース v2026.5.0 へのバージョンバンプ。

## Versions

| Component | Before | After |
|-----------|--------|-------|
| Rox (Project, CalVer) | 2026.4.1 | **2026.5.0** |
| Hono Rox (Backend, SemVer) | 1.5.1 | **1.6.0** |
| Waku Rox (Frontend, SemVer) | 1.5.1 | **1.6.0** |
| Shared (SemVer) | 1.5.1 | **1.6.0** |

## Highlights since v2026.4.1

- **Supply-chain hardening Phase 1** (#164): GitHub Actions SHA固定、frozen-lockfile、最小権限、Dependabot 設定、Dependency Review
- **Supply-chain hardening Phase 2** (#169): リリース時に SBOM (SPDX-JSON) 自動生成 + Sigstore build provenance
- **Waku 1.0.0-beta.0 へアップグレード** (#165) + 各 package で minor/patch 更新
- **better-sqlite3 → bun:sqlite 移行** (#167): ネイティブモジュール撤廃、CI から Node.js 削除、Bun 単一ランタイム化
- 副次: `.playwright-mcp/` を gitignore に追加

## Next steps

- このPRをマージ後、`dev` → `main` のRelease PRを作成して `auto-tag.yml` で v2026.5.0 タグとGitHub Releaseを自動作成