### PR TITLE
fix: address CodeRabbit nitpicks from Release PR #171

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -31,6 +31,18 @@ jobs:
 
             for (const issueNumber of issueNumbers) {
               try {
+                // PRs are also issues in GitHub's data model. Skip them so we
+                // don't accidentally close a PR referenced via "Closes #N".
+                const target = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                });
+                if (target.data.pull_request) {
+                  console.log(`Skipping #${issueNumber}: target is a pull request, not an issue.`);
+                  continue;
+                }
+
                 await github.rest.issues.update({
                   owner: context.repo.owner,
                   repo: context.repo.repo,

--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: sync-dev-with-main
+  cancel-in-progress: true
+
 permissions:
   contents: write
 

--- a/packages/backend/src/db/index.ts
+++ b/packages/backend/src/db/index.ts
@@ -140,7 +140,7 @@ export function createDatabase(): Database {
  * };
  * ```
  */
-export function createD1Database(d1Binding: D1Database): D1DatabaseInstance {
+export function createD1Database(d1Binding: D1Database) {
   // Dynamic import to avoid loading d1 driver in non-Workers environment
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { drizzle: drizzleD1 } = require("drizzle-orm/d1");
@@ -179,8 +179,12 @@ interface D1ExecResult {
 
 /**
  * D1 Database Instance Type
+ *
+ * Inferred from the drizzle-orm/d1 driver return type to keep the public
+ * type in sync with what `createD1Database` actually produces (rather than
+ * the bun:sqlite type, which is a different driver).
  */
-export type D1DatabaseInstance = BunSQLiteDatabase<typeof sqliteSchema>;
+export type D1DatabaseInstance = ReturnType<typeof createD1Database>;
 
 /**
  * Drizzle ORM Database Instance Type

--- a/packages/backend/src/tests/integration/sqlite-repositories.test.ts
+++ b/packages/backend/src/tests/integration/sqlite-repositories.test.ts
@@ -390,8 +390,8 @@ describe("SQLite Repository Integration Tests", () => {
     });
 
     beforeEach(() => {
-      // Clean up notes table before each test
-      sqlite.exec(`DELETE FROM notes WHERE user_id != '${testUserId}'`);
+      // Clean up notes table before each test to ensure isolation.
+      sqlite.exec("DELETE FROM notes");
     });
 
     test("should create a note", async () => {


### PR DESCRIPTION
Release PR #171 のレビューで CodeRabbit が指摘した 4 件のうち、修正に値する 4 件を対応。

## Changes

### 🟠 Major (real bugs)

#### `.github/workflows/close-issues.yml` — auto-close PR 誤動作の可能性
\`Closes #N\` パターンで PR 番号が混入した場合、PR がクローズされてしまう恐れ。\`issues.get\` で対象が PR か事前判定し、その場合は skip するように変更。

#### `packages/backend/src/db/index.ts` — D1 型契約の不一致
\`D1DatabaseInstance\` を \`BunSQLiteDatabase<typeof sqliteSchema>\` として宣言していたが、実際に \`createD1Database\` が返すのは \`drizzle-orm/d1\` driver。型契約がズレており D1 経路で型安全性が失われていた。\`ReturnType<typeof createD1Database>\` で実装に追従させる。

### 🟡 Minor / Quick win

#### `packages/backend/src/tests/integration/sqlite-repositories.test.ts` — テスト間汚染
\`beforeEach\` の \`DELETE FROM notes WHERE user_id != '\${testUserId}'\` は testUserId の note を残してしまい、テスト間でデータがリークしていた。全削除に変更。

#### `.github/workflows/sync-dev.yml` — race condition 対策
main への連続 push で sync ジョブが競合する可能性。\`concurrency: cancel-in-progress\` を追加し、最新の同期だけ走るようにする。

## Test plan

- [x] \`bun run typecheck\` (backend) — pass
- [x] \`bun test src/tests/integration/sqlite-repositories.test.ts\` — 28 pass / 0 fail

## Release continuity

このPRを dev にマージ後、Release PR #171 を更新（dev → main）し、v2026.5.0 リリースを再開する。