### PR TITLE
feat: Sentry によるエラートラッキングを統合

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -256,6 +256,29 @@ REDIS_URL=redis://localhost:6379
 # LOG_LEVEL=info
 
 # =============================================================================
+# Error Tracking (Sentry)
+# =============================================================================
+# Optional. When DSN values are unset, Sentry is fully disabled (no-op).
+
+# Backend DSN (server-side errors)
+# SENTRY_DSN=https://xxxx@xxxx.ingest.sentry.io/xxxx
+
+# Frontend DSN (browser errors). Exposed to the client at build time.
+# VITE_SENTRY_DSN=https://xxxx@xxxx.ingest.sentry.io/xxxx
+
+# Environment tag (defaults to NODE_ENV / MODE)
+# SENTRY_ENVIRONMENT=production
+# VITE_SENTRY_ENVIRONMENT=production
+
+# Performance trace sample rate, float in [0, 1]. Defaults to 0 (disabled).
+# SENTRY_TRACES_SAMPLE_RATE=0.1
+# VITE_SENTRY_TRACES_SAMPLE_RATE=0.1
+
+# Release identifier (e.g. git SHA or app version). Optional.
+# SENTRY_RELEASE=2026.5.0
+# VITE_SENTRY_RELEASE=2026.5.0
+
+# =============================================================================
 # Testing (for development only)
 # =============================================================================
 

--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1045.0",
         "@hono/zod-validator": "^0.8.0",
+        "@sentry/bun": "^10.54.0",
         "@simplewebauthn/server": "^13.3.0",
         "@simplewebauthn/types": "^12.0.0",
         "blurhash": "^2.0.5",
@@ -65,6 +66,7 @@
         "@lingui/message-utils": "^6.0.1",
         "@lingui/react": "^6.0.1",
         "@rolldown/plugin-babel": "^0.2.3",
+        "@sentry/react": "^10.54.0",
         "@simplewebauthn/browser": "^13.3.0",
         "@tailwindcss/vite": "^4.2.0",
         "class-variance-authority": "^0.7.1",
@@ -433,6 +435,18 @@
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.214.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.214.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.214.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
+
     "@oxc-project/runtime": ["@oxc-project/runtime@0.129.0", "", {}, "sha512-0+S67blQakgeNqoKGozOUp5rQBrz2ynXZ2QIINXZPiafsD0YL0UogB9hAWc1S7k6VSNwKYC/N7MqT0V6IzpHkQ=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.129.0", "", {}, "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg=="],
@@ -636,6 +650,28 @@
     "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.53.3", "", { "os": "win32", "cpu": "x64" }, "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg=="],
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.53.3", "", { "os": "win32", "cpu": "x64" }, "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ=="],
+
+    "@sentry-internal/browser-utils": ["@sentry-internal/browser-utils@10.54.0", "", { "dependencies": { "@sentry/core": "10.54.0" } }, "sha512-Cz6NzYFmWJlHh1tvtltKsmLl+1jlseQaPXk18Z0P1g6lXAwhT3aJ99x7vDm4jwCzcJ12qAa8Oga8T3C23Ihijw=="],
+
+    "@sentry-internal/feedback": ["@sentry-internal/feedback@10.54.0", "", { "dependencies": { "@sentry/core": "10.54.0" } }, "sha512-14D+TPgi75zogGQ/EWwtIm34FVWP34gso4SfJZRAoHiQrRfd907q8/7MTXNItxi81x79cH9vweu/o55LBml6MA=="],
+
+    "@sentry-internal/replay": ["@sentry-internal/replay@10.54.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.54.0", "@sentry/core": "10.54.0" } }, "sha512-B7eicNhAomJ7bGihJO7mCw7pZ8FFo/THQgGPo85VR3FaJVCCot20WxVgvhjc7IVBQVlaaxSrnlUFvA+yHjszqQ=="],
+
+    "@sentry-internal/replay-canvas": ["@sentry-internal/replay-canvas@10.54.0", "", { "dependencies": { "@sentry-internal/replay": "10.54.0", "@sentry/core": "10.54.0" } }, "sha512-CGsH019npxnU5cocVDoZKod7JaQtaM6JiR6e2fI8tDwssohJAxP616UQTmoTtBLe3yLG18P4e1BxMxYZFalZEQ=="],
+
+    "@sentry/browser": ["@sentry/browser@10.54.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.54.0", "@sentry-internal/feedback": "10.54.0", "@sentry-internal/replay": "10.54.0", "@sentry-internal/replay-canvas": "10.54.0", "@sentry/core": "10.54.0" } }, "sha512-XYuAA2E4Hf6NOJiP3PqczPgBhFUEsEAh+avgxcYTjTwYdr+Nh5XmDxXATr6RxXUvRASTiYN9zNWyK2o9kEDloA=="],
+
+    "@sentry/bun": ["@sentry/bun@10.54.0", "", { "dependencies": { "@sentry/core": "10.54.0", "@sentry/node": "10.54.0" } }, "sha512-xD3E+Aj+W7D2PCLSEcK2OkNWe659vKb50jKgX9nv2eTmI02O7XGxpyKQqVJVcvLB4xKKLtDEd2AxCmB0o3+NVA=="],
+
+    "@sentry/core": ["@sentry/core@10.54.0", "", {}, "sha512-yC/bc8N5ut6vk9X/ugTnIFAbzaSZ2uGoKiHRGzt7VseDIrjXk5ENDJP0m7Rbchuozr41kBv2QB3mPcHUhfB43w=="],
+
+    "@sentry/node": ["@sentry/node@10.54.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@opentelemetry/core": "^2.6.1", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/sdk-trace-base": "^2.6.1", "@opentelemetry/semantic-conventions": "^1.40.0", "@sentry/core": "10.54.0", "@sentry/node-core": "10.54.0", "@sentry/opentelemetry": "10.54.0", "import-in-the-middle": "^3.0.0" } }, "sha512-Jc31dMBs9aBUv6TXmIPNwv2u18YbfvWQG32IkM3dFWAAoJQhCqLZfN0MEDSf9TeNexIf8qBMZtJRHgHIrWYiGg=="],
+
+    "@sentry/node-core": ["@sentry/node-core@10.54.0", "", { "dependencies": { "@sentry/core": "10.54.0", "@sentry/opentelemetry": "10.54.0", "import-in-the-middle": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1", "@opentelemetry/instrumentation": ">=0.57.1 <1", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/core", "@opentelemetry/exporter-trace-otlp-http", "@opentelemetry/instrumentation", "@opentelemetry/sdk-trace-base", "@opentelemetry/semantic-conventions"] }, "sha512-QR5RnIK78g0Np2+VWMZ3TatM7C+oX9zIQ1W36o3KOjw0nNcXkWjZT1lEu4me8cp2s8s3hA4qT7fwcciQqkj1UQ=="],
+
+    "@sentry/opentelemetry": ["@sentry/opentelemetry@10.54.0", "", { "dependencies": { "@sentry/core": "10.54.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" } }, "sha512-58Jk9yMos5DwhamDsNmnoQMSNx0yD9E+h1pZwkw34ve2qB9tv+cys3Oz6nfazT9ZdIsXIgpQntN8AfMXAvv4/g=="],
+
+    "@sentry/react": ["@sentry/react@10.54.0", "", { "dependencies": { "@sentry/browser": "10.54.0", "@sentry/core": "10.54.0" }, "peerDependencies": { "react": "^16.14.0 || 17.x || 18.x || 19.x" } }, "sha512-P9x2oJwm0LpJC3HUFfvFMcMZt3qW+PFznDk0hl+QI3BO/In07IvzpdQ/nWO81SHt0uwglwGs3bAjnN84YVzXIw=="],
 
     "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g=="],
 
@@ -925,6 +961,8 @@
 
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
+    "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
+
     "acorn-import-phases": ["acorn-import-phases@1.0.4", "", { "peerDependencies": { "acorn": "^8.14.0" } }, "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ=="],
 
     "acorn-loose": ["acorn-loose@8.5.2", "", { "dependencies": { "acorn": "^8.15.0" } }, "sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A=="],
@@ -1016,6 +1054,8 @@
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "chrome-trace-event": ["chrome-trace-event@1.0.4", "", {}, "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ=="],
+
+    "cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
@@ -1187,6 +1227,8 @@
 
     "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
 
+    "import-in-the-middle": ["import-in-the-middle@3.0.1", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA=="],
+
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
@@ -1336,6 +1378,8 @@
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
+
+    "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
     "moo": ["moo@0.5.2", "", {}, "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q=="],
 
@@ -1510,6 +1554,8 @@
     "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
@@ -1737,6 +1783,8 @@
 
     "@jest/types/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
+    "@opentelemetry/api-logs/@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
     "@peculiar/asn1-cms/@peculiar/asn1-x509": ["@peculiar/asn1-x509@2.6.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "asn1js": "^3.0.6", "pvtsutils": "^1.3.6", "tslib": "^2.8.1" } }, "sha512-uzYbPEpoQiBoTq0/+jZtpM6Gq6zADBx+JNFP3yqRgziWBxQ/Dt/HcuvRfm9zJTPdRcBqPNdaRHTVwpyiq6iNMA=="],
 
     "@peculiar/asn1-csr/@peculiar/asn1-x509": ["@peculiar/asn1-x509@2.6.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "asn1js": "^3.0.6", "pvtsutils": "^1.3.6", "tslib": "^2.8.1" } }, "sha512-uzYbPEpoQiBoTq0/+jZtpM6Gq6zADBx+JNFP3yqRgziWBxQ/Dt/HcuvRfm9zJTPdRcBqPNdaRHTVwpyiq6iNMA=="],
@@ -1750,6 +1798,8 @@
     "@peculiar/asn1-x509-attr/@peculiar/asn1-x509": ["@peculiar/asn1-x509@2.6.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "asn1js": "^3.0.6", "pvtsutils": "^1.3.6", "tslib": "^2.8.1" } }, "sha512-uzYbPEpoQiBoTq0/+jZtpM6Gq6zADBx+JNFP3yqRgziWBxQ/Dt/HcuvRfm9zJTPdRcBqPNdaRHTVwpyiq6iNMA=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@sentry/node/@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/docs/implementation/phase-6-production-readiness.md
+++ b/docs/implementation/phase-6-production-readiness.md
@@ -166,15 +166,25 @@ GET /health/ready    → { status: 'ok'|'degraded'|'unhealthy', checks: { databa
 
 ---
 
-### 2.3 Error Tracking (Medium Priority)
+### 2.3 Error Tracking (Medium Priority) ✅ COMPLETE
 
 **Tasks:**
-- [ ] Integrate error tracking (Sentry recommended)
-- [ ] Add breadcrumbs for debugging
+- [x] Integrate error tracking (Sentry)
+- [x] Add breadcrumbs for debugging
 - [ ] Configure source maps for production builds
 - [ ] Set up alert rules for critical errors
 
-**Estimated Impact:** Faster incident response
+**Implementation:**
+- Backend: `@sentry/bun` initialized in `packages/backend/src/index.ts` before other imports. Errors are captured in the `errorHandler` middleware and flushed during graceful shutdown.
+- Frontend: `@sentry/react` initialized in `AppProviders` (client). Both the explicit `ErrorBoundary` and the `GlobalErrorBoundary` forward caught errors via `captureException`.
+- When `SENTRY_DSN` / `VITE_SENTRY_DSN` is unset, the integration is a complete no-op so self-hosted operators are not forced to use Sentry.
+- Configurable via `SENTRY_ENVIRONMENT`, `SENTRY_TRACES_SAMPLE_RATE`, `SENTRY_RELEASE` (and their `VITE_*` counterparts). See `.env.example`.
+
+**Remaining work (tracked separately):**
+- Source map upload during CI for the frontend build
+- Sentry alert/notification rules (Sentry-side configuration)
+
+**Estimated Impact:** Faster incident response ✅ Achieved
 
 ---
 
@@ -449,9 +459,9 @@ GET /health/ready    → { status: 'ok'|'degraded'|'unhealthy', checks: { databa
     - Environment variables reference
     - Troubleshooting guide
 
-12. **Error Tracking** (2.3) - Deferred
-    - Requires Sentry account setup
-    - Can be added post-launch
+12. **Error Tracking** (2.3) ✅
+    - Sentry integration for backend (`@sentry/bun`) and frontend (`@sentry/react`)
+    - No-op when DSN is unset; source map upload tracked separately
 
 ---
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1045.0",
     "@hono/zod-validator": "^0.8.0",
+    "@sentry/bun": "^10.54.0",
     "@simplewebauthn/server": "^13.3.0",
     "@simplewebauthn/types": "^12.0.0",
     "blurhash": "^2.0.5",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,9 +1,12 @@
+// Initialize Sentry BEFORE any other imports so OpenTelemetry-based
+// auto-instrumentation can hook the modules below as they are loaded.
+// ESM evaluates imports top-down; isolating init in `./instrument.js` keeps
+// this ordering correct (a bare `initSentry()` call after other imports would
+// run too late).
+import "./instrument.js";
+
 // Set process title for top/ps visibility
 process.title = "hono-rox";
-
-// Initialize Sentry as early as possible so subsequent imports can be instrumented.
-import { initSentry, flushSentry } from "./lib/sentry.js";
-initSentry();
 
 import { Hono } from "hono";
 import { cors } from "hono/cors";
@@ -15,6 +18,7 @@ import {
   metricsMiddleware,
 } from "./middleware/index.js";
 import { logger } from "./lib/logger.js";
+import { flushSentry } from "./lib/sentry.js";
 import metricsRoute from "./routes/metrics.js";
 import usersRoute from "./routes/users.js";
 import authRoute from "./routes/auth.js";
@@ -258,8 +262,11 @@ async function gracefulShutdown(signal: string): Promise<void> {
   isShuttingDown = true;
   logger.info({ signal }, "Starting graceful shutdown");
 
-  const shutdownTimeout = setTimeout(() => {
+  const shutdownTimeout = setTimeout(async () => {
     logger.error("Shutdown timeout exceeded, forcing exit");
+    // Best-effort flush with a short budget so we don't extend the deadline
+    // significantly when the rest of shutdown is already stuck.
+    await flushSentry(500);
     process.exit(1);
   }, 30000); // 30 second timeout
 
@@ -293,6 +300,8 @@ async function gracefulShutdown(signal: string): Promise<void> {
     process.exit(0);
   } catch (error) {
     logger.error({ err: error }, "Error during shutdown");
+    // Try to ship the shutdown error itself plus any earlier queued events.
+    await flushSentry();
     clearTimeout(shutdownTimeout);
     process.exit(1);
   }

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,6 +1,10 @@
 // Set process title for top/ps visibility
 process.title = "hono-rox";
 
+// Initialize Sentry as early as possible so subsequent imports can be instrumented.
+import { initSentry, flushSentry } from "./lib/sentry.js";
+initSentry();
+
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import {
@@ -279,6 +283,10 @@ async function gracefulShutdown(signal: string): Promise<void> {
     // Shutdown activity delivery queue (drains pending jobs)
     logger.info("Shutting down activity delivery queue");
     await container.activityDeliveryQueue.shutdown();
+
+    // Flush any pending Sentry events before exiting
+    logger.info("Flushing Sentry events");
+    await flushSentry();
 
     logger.info("Graceful shutdown complete");
     clearTimeout(shutdownTimeout);

--- a/packages/backend/src/instrument.ts
+++ b/packages/backend/src/instrument.ts
@@ -1,0 +1,16 @@
+/**
+ * Sentry instrumentation entry point.
+ *
+ * This module is imported via a side-effect import as the very first line of
+ * `src/index.ts`. ESM evaluates imports in order, so isolating Sentry init in
+ * its own module guarantees `Sentry.init` runs before `hono` and the rest of
+ * the application graph are imported — required for OpenTelemetry-based
+ * auto-instrumentation (`@sentry/bun` depends on `@sentry/node` which uses
+ * `import-in-the-middle`).
+ *
+ * @module instrument
+ */
+
+import { initSentry } from "./lib/sentry.js";
+
+initSentry();

--- a/packages/backend/src/lib/sentry.ts
+++ b/packages/backend/src/lib/sentry.ts
@@ -14,6 +14,16 @@ import { logger } from "./logger.js";
 let initialized = false;
 
 /**
+ * Optional context attached to a captured exception.
+ */
+export interface CaptureContext {
+  /** Indexed tags (low cardinality, suitable for filtering in Sentry UI). */
+  tags?: Record<string, string>;
+  /** Free-form extras (high cardinality OK, not indexed for search). */
+  extras?: Record<string, unknown>;
+}
+
+/**
  * Initialize Sentry from environment variables.
  *
  * Reads:
@@ -39,13 +49,21 @@ export function initSentry(): void {
     environment: process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || "development",
     release: process.env.SENTRY_RELEASE,
     tracesSampleRate,
-    // Strip request bodies and cookies by default to minimize PII exposure.
-    // ActivityPub payloads frequently contain user-generated content.
+    // Suppress the default server_name. Passing an empty string is NOT
+    // enough — Sentry treats it as falsy and falls back to
+    // `SENTRY_NAME` env / `os.hostname()`. `includeServerName: false` is
+    // the documented opt-out.
+    includeServerName: false,
+    // Strip request bodies, cookies, headers, and query strings by default to
+    // minimize PII exposure. ActivityPub payloads and Authorization /
+    // Cookie / Signature headers can all contain secrets.
     sendDefaultPii: false,
     beforeSend(event) {
       if (event.request) {
         delete event.request.cookies;
         delete event.request.data;
+        delete event.request.headers;
+        delete event.request.query_string;
       }
       return event;
     },
@@ -65,12 +83,9 @@ export function initSentry(): void {
  * Capture an exception in Sentry. No-op when Sentry is not initialized.
  *
  * @param error - The error to capture
- * @param context - Optional context (tags, extras) merged into the event
+ * @param context - Optional tags (indexed) and extras (free-form) for the event
  */
-export function captureException(
-  error: unknown,
-  context?: { tags?: Record<string, string>; extras?: Record<string, unknown> },
-): void {
+export function captureException(error: unknown, context?: CaptureContext): void {
   if (!initialized) return;
 
   Sentry.withScope((scope) => {
@@ -96,8 +111,48 @@ export function isSentryEnabled(): boolean {
 }
 
 /**
+ * Schedule descriptor for a recurring background task. Maps to Sentry's
+ * MonitorConfig.schedule field.
+ *
+ * - `crontab`: cron expression, e.g. `"0 * * * *"` (every hour).
+ * - `interval`: numeric interval, e.g. `{ type: "interval", value: 30, unit: "minute" }`.
+ */
+export type MonitorSchedule =
+  | { type: "crontab"; value: string }
+  | { type: "interval"; value: number; unit: "minute" | "hour" | "day" | "week" | "month" | "year" };
+
+/**
+ * Run a callback under a Sentry cron check-in. The callback runs unconditionally;
+ * when Sentry is not initialized, this is a transparent pass-through.
+ *
+ * The check-in pattern: a single `in_progress` event is emitted before the
+ * callback, then `ok` or `error` based on whether the callback resolves or
+ * rejects. If a check-in is not received within the configured schedule
+ * window, Sentry alerts.
+ *
+ * @param monitorSlug - Sentry monitor slug (configure server-side or via `schedule` for auto-upsert)
+ * @param callback - The async task to run
+ * @param schedule - Optional schedule for monitor auto-upsert
+ * @returns Whatever the callback returns
+ */
+export async function withMonitor<T>(
+  monitorSlug: string,
+  callback: () => Promise<T>,
+  schedule?: MonitorSchedule,
+): Promise<T> {
+  if (!initialized) {
+    return callback();
+  }
+  const monitorConfig = schedule ? { schedule } : undefined;
+  return Sentry.withMonitor(monitorSlug, callback, monitorConfig);
+}
+
+/**
  * Flush queued Sentry events. Call during graceful shutdown to avoid losing
  * events still in the network buffer.
+ *
+ * Logs a warning when the queue does not drain within the timeout so that
+ * operators have visibility into dropped events.
  *
  * @param timeoutMs - Maximum time to wait in milliseconds
  * @returns `true` if the queue drained within the timeout
@@ -105,12 +160,25 @@ export function isSentryEnabled(): boolean {
 export async function flushSentry(timeoutMs = 2000): Promise<boolean> {
   if (!initialized) return true;
   try {
-    return await Sentry.flush(timeoutMs);
-  } catch {
+    const drained = await Sentry.flush(timeoutMs);
+    if (!drained) {
+      logger.warn({ timeoutMs }, "Sentry flush did not drain within timeout");
+    }
+    return drained;
+  } catch (err) {
+    logger.warn({ err }, "Sentry flush threw");
     return false;
   }
 }
 
+/**
+ * Parse the `SENTRY_TRACES_SAMPLE_RATE` env var into a value Sentry accepts.
+ *
+ * Returns `0` for unset / non-numeric input, and clamps to `[0, 1]`.
+ *
+ * @param raw - Raw env var value
+ * @returns Sample rate in `[0, 1]`
+ */
 function parseSampleRate(raw: string | undefined): number {
   if (!raw) return 0;
   const parsed = Number.parseFloat(raw);

--- a/packages/backend/src/lib/sentry.ts
+++ b/packages/backend/src/lib/sentry.ts
@@ -1,0 +1,121 @@
+/**
+ * Sentry Integration
+ *
+ * Initializes Sentry error tracking for the backend. When `SENTRY_DSN` is not
+ * set, all helpers become no-ops so self-hosted operators are not forced to
+ * use Sentry.
+ *
+ * @module lib/sentry
+ */
+
+import * as Sentry from "@sentry/bun";
+import { logger } from "./logger.js";
+
+let initialized = false;
+
+/**
+ * Initialize Sentry from environment variables.
+ *
+ * Reads:
+ * - `SENTRY_DSN`: Project DSN. Required; if missing, initialization is skipped.
+ * - `SENTRY_ENVIRONMENT`: Environment tag (falls back to `NODE_ENV`).
+ * - `SENTRY_TRACES_SAMPLE_RATE`: Float in `[0, 1]`. Defaults to `0` (no tracing).
+ * - `SENTRY_RELEASE`: Release identifier. Optional.
+ *
+ * Safe to call multiple times; subsequent calls are ignored.
+ */
+export function initSentry(): void {
+  if (initialized) return;
+
+  const dsn = process.env.SENTRY_DSN;
+  if (!dsn) {
+    return;
+  }
+
+  const tracesSampleRate = parseSampleRate(process.env.SENTRY_TRACES_SAMPLE_RATE);
+
+  Sentry.init({
+    dsn,
+    environment: process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || "development",
+    release: process.env.SENTRY_RELEASE,
+    tracesSampleRate,
+    // Strip request bodies and cookies by default to minimize PII exposure.
+    // ActivityPub payloads frequently contain user-generated content.
+    sendDefaultPii: false,
+    beforeSend(event) {
+      if (event.request) {
+        delete event.request.cookies;
+        delete event.request.data;
+      }
+      return event;
+    },
+  });
+
+  initialized = true;
+  logger.info(
+    {
+      environment: process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || "development",
+      tracesSampleRate,
+    },
+    "Sentry initialized",
+  );
+}
+
+/**
+ * Capture an exception in Sentry. No-op when Sentry is not initialized.
+ *
+ * @param error - The error to capture
+ * @param context - Optional context (tags, extras) merged into the event
+ */
+export function captureException(
+  error: unknown,
+  context?: { tags?: Record<string, string>; extras?: Record<string, unknown> },
+): void {
+  if (!initialized) return;
+
+  Sentry.withScope((scope) => {
+    if (context?.tags) {
+      for (const [key, value] of Object.entries(context.tags)) {
+        scope.setTag(key, value);
+      }
+    }
+    if (context?.extras) {
+      for (const [key, value] of Object.entries(context.extras)) {
+        scope.setExtra(key, value);
+      }
+    }
+    Sentry.captureException(error);
+  });
+}
+
+/**
+ * Whether Sentry has been initialized with a valid DSN.
+ */
+export function isSentryEnabled(): boolean {
+  return initialized;
+}
+
+/**
+ * Flush queued Sentry events. Call during graceful shutdown to avoid losing
+ * events still in the network buffer.
+ *
+ * @param timeoutMs - Maximum time to wait in milliseconds
+ * @returns `true` if the queue drained within the timeout
+ */
+export async function flushSentry(timeoutMs = 2000): Promise<boolean> {
+  if (!initialized) return true;
+  try {
+    return await Sentry.flush(timeoutMs);
+  } catch {
+    return false;
+  }
+}
+
+function parseSampleRate(raw: string | undefined): number {
+  if (!raw) return 0;
+  const parsed = Number.parseFloat(raw);
+  if (!Number.isFinite(parsed)) return 0;
+  if (parsed < 0) return 0;
+  if (parsed > 1) return 1;
+  return parsed;
+}

--- a/packages/backend/src/middleware/errorHandler.ts
+++ b/packages/backend/src/middleware/errorHandler.ts
@@ -7,6 +7,7 @@
  */
 import type { Context, Next } from "hono";
 import { HTTPException } from "hono/http-exception";
+import { routePath } from "hono/route";
 import { logger } from "../lib/logger.js";
 import { captureException } from "../lib/sentry.js";
 
@@ -41,8 +42,24 @@ export async function errorHandler(c: Context, next: Next) {
 
     // その他のエラーはログに記録して500エラーを返す
     logger.error({ err: error }, "Unhandled error");
+    // `route` is the Hono route template (low cardinality) which makes a
+    // useful tag. The resolved path can have unbounded cardinality (UUIDs,
+    // proxied URLs, ...), so it goes into extras. We deliberately use
+    // `c.req.path` (no query string) — `c.req.url` would leak OAuth `code`,
+    // session tokens, and other secrets that `beforeSend` strips from
+    // `event.request.query_string`.
+    //
+    // `routePath(c)` reads Hono's match result, which may not be populated
+    // when an error fires before routing completes. Fall back gracefully.
+    let route = "<unmatched>";
+    try {
+      route = routePath(c) || route;
+    } catch {
+      // Match result not available yet — leave the placeholder.
+    }
     captureException(error, {
-      tags: { method: c.req.method, path: new URL(c.req.url).pathname },
+      tags: { method: c.req.method, route },
+      extras: { path: c.req.path },
     });
 
     return c.json(

--- a/packages/backend/src/middleware/errorHandler.ts
+++ b/packages/backend/src/middleware/errorHandler.ts
@@ -8,6 +8,7 @@
 import type { Context, Next } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { logger } from "../lib/logger.js";
+import { captureException } from "../lib/sentry.js";
 
 /**
  * Global Error Handler
@@ -40,6 +41,9 @@ export async function errorHandler(c: Context, next: Next) {
 
     // その他のエラーはログに記録して500エラーを返す
     logger.error({ err: error }, "Unhandled error");
+    captureException(error, {
+      tags: { method: c.req.method, path: new URL(c.req.url).pathname },
+    });
 
     return c.json(
       {

--- a/packages/backend/src/services/ReceivedActivitiesCleanupService.ts
+++ b/packages/backend/src/services/ReceivedActivitiesCleanupService.ts
@@ -11,6 +11,7 @@ import { getDatabase } from "../db/index.js";
 import { receivedActivities } from "../db/schema/pg.js";
 import { lt } from "drizzle-orm";
 import { logger } from "../lib/logger.js";
+import { withMonitor } from "../lib/sentry.js";
 
 /**
  * Cleanup configuration
@@ -80,16 +81,31 @@ export class ReceivedActivitiesCleanupService {
     );
 
     // Run cleanup immediately on start
-    this.cleanup().catch((error) => {
+    this.runMonitored().catch((error) => {
       logger.error({ err: error }, "Initial cleanup failed");
     });
 
     // Schedule periodic cleanup
     this.intervalId = setInterval(() => {
-      this.cleanup().catch((error) => {
+      this.runMonitored().catch((error) => {
         logger.error({ err: error }, "Scheduled cleanup failed");
       });
     }, this.config.intervalMs);
+  }
+
+  /**
+   * Run one cleanup pass wrapped in a Sentry cron check-in (no-op when Sentry
+   * is disabled).
+   *
+   * @private
+   */
+  private runMonitored(): Promise<number> {
+    const intervalMinutes = Math.max(1, Math.round(this.config.intervalMs / 60_000));
+    return withMonitor(
+      "rox-received-activities-cleanup",
+      () => this.cleanup(),
+      { type: "interval", value: intervalMinutes, unit: "minute" },
+    );
   }
 
   /**

--- a/packages/backend/src/services/RemoteInstanceRefreshService.ts
+++ b/packages/backend/src/services/RemoteInstanceRefreshService.ts
@@ -1,6 +1,7 @@
 import type { IRemoteInstanceRepository } from "../interfaces/repositories/IRemoteInstanceRepository.js";
 import { logger } from "../lib/logger.js";
 import { fetchInstanceIcon } from "../lib/instance-icon.js";
+import { withMonitor } from "../lib/sentry.js";
 
 /**
  * NodeInfo 2.0/2.1 response structure
@@ -120,16 +121,31 @@ export class RemoteInstanceRefreshService {
     );
 
     // Run refresh immediately on start
-    this.refresh().catch((error) => {
+    this.runMonitored().catch((error) => {
       logger.error({ err: error }, "Initial remote instance refresh failed");
     });
 
     // Schedule periodic refresh
     this.intervalId = setInterval(() => {
-      this.refresh().catch((error) => {
+      this.runMonitored().catch((error) => {
         logger.error({ err: error }, "Scheduled remote instance refresh failed");
       });
     }, this.config.intervalMs);
+  }
+
+  /**
+   * Run one refresh pass wrapped in a Sentry cron check-in (no-op when Sentry
+   * is disabled).
+   *
+   * @private
+   */
+  private runMonitored(): Promise<number> {
+    const intervalMinutes = Math.max(1, Math.round(this.config.intervalMs / 60_000));
+    return withMonitor(
+      "rox-remote-instance-refresh",
+      () => this.refresh(),
+      { type: "interval", value: intervalMinutes, unit: "minute" },
+    );
   }
 
   /**

--- a/packages/backend/src/services/ScheduledNotePublisher.ts
+++ b/packages/backend/src/services/ScheduledNotePublisher.ts
@@ -9,6 +9,7 @@
 
 import type { ScheduledNoteService } from "./ScheduledNoteService.js";
 import { createLogger } from "../lib/logger.js";
+import { withMonitor } from "../lib/sentry.js";
 
 const logger = createLogger({ name: "ScheduledNotePublisher" });
 
@@ -85,16 +86,32 @@ export class ScheduledNotePublisher {
     );
 
     // Run immediately on start
-    this.processScheduledNotes().catch((error) => {
+    this.runMonitored().catch((error) => {
       logger.error({ err: error }, "Initial scheduled note processing failed");
     });
 
     // Schedule periodic processing
     this.intervalId = setInterval(() => {
-      this.processScheduledNotes().catch((error) => {
+      this.runMonitored().catch((error) => {
         logger.error({ err: error }, "Scheduled note processing failed");
       });
     }, this.config.intervalMs);
+  }
+
+  /**
+   * Run one processing pass wrapped in a Sentry cron check-in (no-op when
+   * Sentry is disabled). Sentry's interval-based monitors have a minimum
+   * granularity of 1 minute; the publisher fires more frequently than that,
+   * which is harmless — Sentry just sees multiple check-ins per window.
+   *
+   * @private
+   */
+  private runMonitored(): Promise<number> {
+    return withMonitor(
+      "rox-scheduled-note-publisher",
+      () => this.processScheduledNotes(),
+      { type: "interval", value: 1, unit: "minute" },
+    );
   }
 
   /**

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -23,6 +23,7 @@
     "@lingui/message-utils": "^6.0.1",
     "@lingui/react": "^6.0.1",
     "@rolldown/plugin-babel": "^0.2.3",
+    "@sentry/react": "^10.54.0",
     "@simplewebauthn/browser": "^13.3.0",
     "@tailwindcss/vite": "^4.2.0",
     "class-variance-authority": "^0.7.1",

--- a/packages/frontend/src/components/AppProviders.tsx
+++ b/packages/frontend/src/components/AppProviders.tsx
@@ -15,6 +15,7 @@ import { tokenAtom } from "../lib/atoms/auth";
 import { apiClient } from "../lib/api/client";
 import type { ThemeSettings } from "../lib/types/instance";
 import { recordNavigation } from "../hooks/useNavigationHistory";
+import { initSentry, captureException } from "../lib/sentry";
 
 /**
  * Check if an error message indicates a portal cleanup error.
@@ -51,6 +52,8 @@ class GlobalErrorBoundary extends Component<{ children: ReactNode }, { hasError:
       console.warn("Portal cleanup error detected, attempting recovery...");
       this.setState({ hasError: false });
     } else {
+      // Report non-portal errors to Sentry before rethrowing
+      captureException(error, { source: "GlobalErrorBoundary" });
       // Rethrow non-portal errors to propagate to higher-level handlers
       throw error;
     }
@@ -79,6 +82,11 @@ export function AppProviders({ children }: AppProvidersProps) {
   const [theme, setTheme] = useState<ThemeSettings | undefined>(undefined);
   const [isLoaded, setIsLoaded] = useState(false);
   const token = useAtomValue(tokenAtom);
+
+  // Initialize Sentry on the client. No-op when VITE_SENTRY_DSN is unset.
+  useEffect(() => {
+    initSentry();
+  }, []);
 
   // Sync token to apiClient whenever it changes
   useEffect(() => {

--- a/packages/frontend/src/components/AppProviders.tsx
+++ b/packages/frontend/src/components/AppProviders.tsx
@@ -15,7 +15,9 @@ import { tokenAtom } from "../lib/atoms/auth";
 import { apiClient } from "../lib/api/client";
 import type { ThemeSettings } from "../lib/types/instance";
 import { recordNavigation } from "../hooks/useNavigationHistory";
-import { initSentry, captureException } from "../lib/sentry";
+// `lib/sentry` calls `initSentry()` at module load time (browser-only) so
+// error boundaries firing during the first render can still report.
+import { captureException } from "../lib/sentry";
 
 /**
  * Check if an error message indicates a portal cleanup error.
@@ -52,9 +54,13 @@ class GlobalErrorBoundary extends Component<{ children: ReactNode }, { hasError:
       console.warn("Portal cleanup error detected, attempting recovery...");
       this.setState({ hasError: false });
     } else {
-      // Report non-portal errors to Sentry before rethrowing
-      captureException(error, { source: "GlobalErrorBoundary" });
-      // Rethrow non-portal errors to propagate to higher-level handlers
+      // Capture explicitly first — React 19's rethrow only propagates to
+      // window.onerror while this stays the outermost boundary. A wrapper
+      // boundary added later would silently swallow it. Sentry's
+      // dedupeIntegration handles any duplicate from globalHandlers.
+      captureException(error, { tags: { source: "GlobalErrorBoundary" } });
+      // Rethrow so React unmounts the broken subtree (preserves the original
+      // behavior of this boundary).
       throw error;
     }
   }
@@ -82,11 +88,6 @@ export function AppProviders({ children }: AppProvidersProps) {
   const [theme, setTheme] = useState<ThemeSettings | undefined>(undefined);
   const [isLoaded, setIsLoaded] = useState(false);
   const token = useAtomValue(tokenAtom);
-
-  // Initialize Sentry on the client. No-op when VITE_SENTRY_DSN is unset.
-  useEffect(() => {
-    initSentry();
-  }, []);
 
   // Sync token to apiClient whenever it changes
   useEffect(() => {

--- a/packages/frontend/src/components/ui/ErrorBoundary.tsx
+++ b/packages/frontend/src/components/ui/ErrorBoundary.tsx
@@ -4,6 +4,7 @@ import { Component, type ReactNode } from "react";
 import { Trans } from "@lingui/react/macro";
 import { AlertTriangle, RefreshCw } from "lucide-react";
 import { Button } from "./Button";
+import { captureException } from "../../lib/sentry";
 
 /**
  * Props for the ErrorBoundary component
@@ -53,6 +54,12 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
     // Log error to console for debugging
     console.error("ErrorBoundary caught an error:", error, errorInfo);
+
+    // Report to Sentry (no-op when DSN is unset)
+    captureException(error, {
+      source: "ErrorBoundary",
+      componentStack: errorInfo.componentStack,
+    });
 
     // Call optional error callback
     this.props.onError?.(error, errorInfo);

--- a/packages/frontend/src/components/ui/ErrorBoundary.tsx
+++ b/packages/frontend/src/components/ui/ErrorBoundary.tsx
@@ -55,10 +55,12 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     // Log error to console for debugging
     console.error("ErrorBoundary caught an error:", error, errorInfo);
 
-    // Report to Sentry (no-op when DSN is unset)
+    // Report to Sentry (no-op when DSN is unset). This boundary does NOT
+    // rethrow, so globalHandlersIntegration won't see the error — explicit
+    // capture is required.
     captureException(error, {
-      source: "ErrorBoundary",
-      componentStack: errorInfo.componentStack,
+      tags: { source: "ErrorBoundary" },
+      extras: { componentStack: errorInfo.componentStack },
     });
 
     // Call optional error callback

--- a/packages/frontend/src/lib/sentry.ts
+++ b/packages/frontend/src/lib/sentry.ts
@@ -12,6 +12,19 @@ import * as Sentry from "@sentry/react";
 let initialized = false;
 
 /**
+ * Optional context attached to a captured exception.
+ *
+ * Kept structurally identical to the backend helper so the same call shape
+ * works in both environments.
+ */
+export interface CaptureContext {
+  /** Indexed tags (low cardinality, suitable for filtering in Sentry UI). */
+  tags?: Record<string, string>;
+  /** Free-form extras (high cardinality OK, not indexed for search). */
+  extras?: Record<string, unknown>;
+}
+
+/**
  * Initialize Sentry from Vite env. Safe to call multiple times.
  *
  * Reads:
@@ -48,13 +61,18 @@ export function initSentry(): void {
  * Capture an exception in Sentry. No-op when Sentry is not initialized.
  *
  * @param error - The error to capture
- * @param context - Optional extras merged into the event
+ * @param context - Optional tags (indexed) and extras (free-form) for the event
  */
-export function captureException(error: unknown, context?: Record<string, unknown>): void {
+export function captureException(error: unknown, context?: CaptureContext): void {
   if (!initialized) return;
   Sentry.withScope((scope) => {
-    if (context) {
-      for (const [key, value] of Object.entries(context)) {
+    if (context?.tags) {
+      for (const [key, value] of Object.entries(context.tags)) {
+        scope.setTag(key, value);
+      }
+    }
+    if (context?.extras) {
+      for (const [key, value] of Object.entries(context.extras)) {
         scope.setExtra(key, value);
       }
     }
@@ -69,6 +87,14 @@ export function isSentryEnabled(): boolean {
   return initialized;
 }
 
+/**
+ * Parse the `VITE_SENTRY_TRACES_SAMPLE_RATE` env var into a value Sentry accepts.
+ *
+ * Returns `0` for unset / non-numeric input, and clamps to `[0, 1]`.
+ *
+ * @param raw - Raw env var value
+ * @returns Sample rate in `[0, 1]`
+ */
 function parseSampleRate(raw: string | undefined): number {
   if (!raw) return 0;
   const parsed = Number.parseFloat(raw);
@@ -77,3 +103,8 @@ function parseSampleRate(raw: string | undefined): number {
   if (parsed > 1) return 1;
   return parsed;
 }
+
+// Initialize on module load so error boundaries firing during the first
+// render phase (which runs synchronously before any useEffect) can still
+// report. The function short-circuits during SSR (`typeof window`).
+initSentry();

--- a/packages/frontend/src/lib/sentry.ts
+++ b/packages/frontend/src/lib/sentry.ts
@@ -52,6 +52,25 @@ export function initSentry(): void {
     release: env.VITE_SENTRY_RELEASE as string | undefined,
     tracesSampleRate,
     sendDefaultPii: false,
+    beforeSend(event) {
+      // Drop request bodies, cookies, headers, and query strings to minimize
+      // PII exposure (Authorization headers, session cookies, OAuth `code` /
+      // `state` in query strings, etc.) — mirrors the backend hook.
+      if (event.request) {
+        delete event.request.cookies;
+        delete event.request.data;
+        delete event.request.headers;
+        delete event.request.query_string;
+      }
+      // `sendDefaultPii: false` already suppresses IP/UA, but defensively
+      // drop email / username / ip if a future call site adds them.
+      if (event.user) {
+        delete event.user.email;
+        delete event.user.username;
+        delete event.user.ip_address;
+      }
+      return event;
+    },
   });
 
   initialized = true;

--- a/packages/frontend/src/lib/sentry.ts
+++ b/packages/frontend/src/lib/sentry.ts
@@ -1,0 +1,79 @@
+/**
+ * Sentry Integration (frontend)
+ *
+ * Browser-side Sentry initialization. When `VITE_SENTRY_DSN` is not set, all
+ * helpers become no-ops so self-hosted operators are not forced to use Sentry.
+ *
+ * @module lib/sentry
+ */
+
+import * as Sentry from "@sentry/react";
+
+let initialized = false;
+
+/**
+ * Initialize Sentry from Vite env. Safe to call multiple times.
+ *
+ * Reads:
+ * - `VITE_SENTRY_DSN`: Project DSN. Required; if missing, initialization is skipped.
+ * - `VITE_SENTRY_ENVIRONMENT`: Environment tag (falls back to `MODE`).
+ * - `VITE_SENTRY_TRACES_SAMPLE_RATE`: Float in `[0, 1]`. Defaults to `0`.
+ * - `VITE_SENTRY_RELEASE`: Release identifier. Optional.
+ */
+export function initSentry(): void {
+  if (initialized) return;
+  if (typeof window === "undefined") return;
+
+  const env = import.meta.env;
+  const dsn = env.VITE_SENTRY_DSN as string | undefined;
+  if (!dsn) return;
+
+  const tracesSampleRate = parseSampleRate(
+    env.VITE_SENTRY_TRACES_SAMPLE_RATE as string | undefined,
+  );
+
+  Sentry.init({
+    dsn,
+    environment:
+      (env.VITE_SENTRY_ENVIRONMENT as string | undefined) || (env.MODE as string) || "development",
+    release: env.VITE_SENTRY_RELEASE as string | undefined,
+    tracesSampleRate,
+    sendDefaultPii: false,
+  });
+
+  initialized = true;
+}
+
+/**
+ * Capture an exception in Sentry. No-op when Sentry is not initialized.
+ *
+ * @param error - The error to capture
+ * @param context - Optional extras merged into the event
+ */
+export function captureException(error: unknown, context?: Record<string, unknown>): void {
+  if (!initialized) return;
+  Sentry.withScope((scope) => {
+    if (context) {
+      for (const [key, value] of Object.entries(context)) {
+        scope.setExtra(key, value);
+      }
+    }
+    Sentry.captureException(error);
+  });
+}
+
+/**
+ * Whether Sentry has been initialized with a valid DSN.
+ */
+export function isSentryEnabled(): boolean {
+  return initialized;
+}
+
+function parseSampleRate(raw: string | undefined): number {
+  if (!raw) return 0;
+  const parsed = Number.parseFloat(raw);
+  if (!Number.isFinite(parsed)) return 0;
+  if (parsed < 0) return 0;
+  if (parsed > 1) return 1;
+  return parsed;
+}


### PR DESCRIPTION
Closes #204

## Summary

- Backend (`@sentry/bun`) と Frontend (`@sentry/react`) に Sentry を統合
- `SENTRY_DSN` / `VITE_SENTRY_DSN` 未設定時は完全 no-op (self-host 配慮)
- Backend は `errorHandler` middleware で例外をキャプチャし、graceful shutdown で flush
- Frontend は `AppProviders` で初期化し、`ErrorBoundary` / `GlobalErrorBoundary` から `captureException` 経由でレポート
- `.env.example` に `SENTRY_*` / `VITE_SENTRY_*` を追加、Phase 6 ドキュメントの該当項目を完了済みに更新

## Out of scope (follow-up)

- フロントエンドビルド時のソースマップアップロード (CI 連携が必要なため別 issue で対応)
- Sentry 側のアラートルール設定

## Test plan

- [x] `bun run typecheck` (backend + frontend)
- [x] `bun run lint`
- [x] `bun test:unit` (1012 / 1012 pass)
- [ ] DSN を設定した状態で実際に Sentry にイベントが届くことを確認 (任意の DSN で検証推奨)
- [ ] DSN 未設定時に SDK 関連の副作用が一切ないことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Sentryエラートラッキングサービスをバックエンドとフロントエンドに統合し、エラー監視と診断機能を強化しました。
  * 環境変数設定を拡充し、本番環境でのエラー追跡をサポートします。

* **Documentation**
  * Sentry統合の設定と実装方法をドキュメントに反映しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Love-Rox/rox/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->