### PR TITLE
chore: bump version to 2026.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rox",
-  "version": "2026.5.0",
+  "version": "2026.5.1",
   "license": "AGPL-3.0-only",
   "devDependencies": {
     "@playwright/test": "^1.60.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hono_rox",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waku_rox",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shared",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
## Summary

Bump version to **2026.5.1** in preparation for release.

| Package | from | to |
|---------|------|------|
| root (CalVer) | 2026.5.0 | **2026.5.1** |
| hono_rox (backend) | 1.6.0 | **1.7.0** |
| waku_rox (frontend) | 1.6.0 | **1.7.0** |
| shared | 1.6.0 | **1.7.0** |

## Highlights since v2026.5.0

- **feat: Sentry / GlitchTip error tracking integration** (#204 / #205)
  - Backend (`@sentry/bun`) + Frontend (`@sentry/react`)
  - No-op when DSN is unset
  - `withMonitor` heartbeat for background services
  - PII scrubbed via `beforeSend`
- **chore: Dependabot now targets `dev`** (#206 / #207)

## Test plan

- [x] Verified on production VPS (dev branch deployed)
- [x] Sentry initialization confirmed in journal
- [x] Test event delivered to GlitchTip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * パッケージのバージョンを更新しました。メインパッケージは2026.5.1、バックエンド・フロントエンド・共有パッケージは1.7.0となります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Love-Rox/rox/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->