### PR TITLE
chore: refresh bun.lock workspace versions to 1.7.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "packages/backend": {
       "name": "hono_rox",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1045.0",
         "@hono/zod-validator": "^0.8.0",
@@ -56,7 +56,7 @@
     },
     "packages/frontend": {
       "name": "waku_rox",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -106,7 +106,7 @@
     },
     "packages/shared": {
       "name": "shared",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "dependencies": {
         "vite-plus": "^0.1.21",
       },


### PR DESCRIPTION
Follow-up to #208 (CodeRabbit nit).

bun.lock had `packages/{backend,frontend,shared}` "version" still pinned to 1.6.0 after the package.json bump. This patch updates only those three metadata lines so the release PR (#209) carries a coherent lock.

## Test plan

- [x] `bun install --frozen-lockfile` succeeds (no drift, no churn)
- [x] Diff is exactly 3 lines (verified via `git diff --stat`)