### PR TITLE
ci: use RELEASE_PAT for tag push + dev sync workflows

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -23,6 +23,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
         with:
           fetch-depth: 0
+          # Use RELEASE_PAT so that:
+          #   - the tag push escapes the default GITHUB_TOKEN's ruleset constraints
+          #   - the tag push fires downstream workflow events (GITHUB_TOKEN does not)
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Get version from package.json
         id: version
@@ -81,6 +85,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
         with:
           fetch-depth: 0
+          # Use RELEASE_PAT so that:
+          #   - the tag push escapes the default GITHUB_TOKEN's ruleset constraints
+          #   - the tag push fires downstream workflow events (GITHUB_TOKEN does not)
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Get previous tag
         id: prev_tag

--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -20,6 +20,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
         with:
           fetch-depth: 0
+          # PAT required: GITHUB_TOKEN's `git push origin dev` is rejected by
+          # the repository ruleset with `remote: fatal error in commit_refs`.
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Sync dev branch
         run: |


### PR DESCRIPTION
The default GITHUB_TOKEN's `git push` is rejected by the repository ruleset (`remote: fatal error in commit_refs`) when:
- `auto-tag.yml` pushes a release tag
- `sync-dev.yml` pushes the dev branch fast-forward

Both have been failing every release since the ruleset was applied (we worked around it manually for v2026.5.1).

This PR switches both workflows to use a repository-scoped PAT via `secrets.RELEASE_PAT`. Once the secret is configured, automated tagging + dev sync resumes (and a side-benefit: PAT pushes fire `push` events, which is required for the `create-release` job in auto-tag.yml to chain off the tag push).

## Setup (one-time, owner action)

1. Create a [fine-grained PAT](https://github.com/settings/personal-access-tokens/new) scoped to **Love-Rox/rox only** with permissions:
   - **Contents**: Read and write
   - **Workflows**: Read and write
2. Add it as a repo secret named `RELEASE_PAT` at <https://github.com/Love-Rox/rox/settings/secrets/actions>
3. Merge this PR

## Verification

- [ ] On next release (bump → dev → main), auto-tag.yml succeeds and the tag triggers create-release
- [ ] sync-dev.yml succeeds after the merge to main

## Risk

A leaked PAT could push directly to main / tags, bypassing PR review. Use a fine-grained PAT scoped only to this repo so the blast radius is limited. Rotate periodically.