### PR TITLE
feat: multiplexed Sentry transport for parallel backends

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -278,6 +278,13 @@ REDIS_URL=redis://localhost:6379
 # SENTRY_RELEASE=2026.5.0
 # VITE_SENTRY_RELEASE=2026.5.0
 
+# Optional second destination DSN. When set, every event is sent to BOTH
+# SENTRY_DSN and SENTRY_SECONDARY_DSN via a multiplexed transport. Useful
+# for A/B comparing GlitchTip / Sentry / Bugsink side by side. Each
+# destination retries independently.
+# SENTRY_SECONDARY_DSN=
+# VITE_SENTRY_SECONDARY_DSN=
+
 # =============================================================================
 # Testing (for development only)
 # =============================================================================

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "@aws-sdk/client-s3": "^3.1045.0",
         "@hono/zod-validator": "^0.8.0",
         "@sentry/bun": "^10.54.0",
+        "@sentry/core": "10.54.0",
         "@simplewebauthn/server": "^13.3.0",
         "@simplewebauthn/types": "^12.0.0",
         "blurhash": "^2.0.5",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -23,6 +23,7 @@
     "@aws-sdk/client-s3": "^3.1045.0",
     "@hono/zod-validator": "^0.8.0",
     "@sentry/bun": "^10.54.0",
+    "@sentry/core": "10.54.0",
     "@simplewebauthn/server": "^13.3.0",
     "@simplewebauthn/types": "^12.0.0",
     "blurhash": "^2.0.5",

--- a/packages/backend/src/lib/sentry.ts
+++ b/packages/backend/src/lib/sentry.ts
@@ -9,6 +9,8 @@
  */
 
 import * as Sentry from "@sentry/bun";
+import { makeNodeTransport } from "@sentry/bun";
+import { makeMultiplexedTransport } from "@sentry/core";
 import { logger } from "./logger.js";
 
 let initialized = false;
@@ -28,6 +30,10 @@ export interface CaptureContext {
  *
  * Reads:
  * - `SENTRY_DSN`: Project DSN. Required; if missing, initialization is skipped.
+ * - `SENTRY_SECONDARY_DSN`: Optional additional DSN. When set, every event is
+ *   sent to BOTH DSNs via a multiplexed transport. Useful for A/B comparing
+ *   error-tracking backends (e.g. GlitchTip vs Sentry vs Bugsink) without
+ *   duplicating the SDK setup.
  * - `SENTRY_ENVIRONMENT`: Environment tag (falls back to `NODE_ENV`).
  * - `SENTRY_TRACES_SAMPLE_RATE`: Float in `[0, 1]`. Defaults to `0` (no tracing).
  * - `SENTRY_RELEASE`: Release identifier. Optional.
@@ -44,11 +50,20 @@ export function initSentry(): void {
 
   const tracesSampleRate = parseSampleRate(process.env.SENTRY_TRACES_SAMPLE_RATE);
 
+  // Optional fan-out: send every event to a second backend too (e.g. for
+  // comparing GlitchTip / Sentry / Bugsink side by side). Each destination
+  // gets its own retry queue, so a flaky secondary does not block primary.
+  const secondaryDsn = process.env.SENTRY_SECONDARY_DSN;
+  const routes = [dsn, ...(secondaryDsn ? [secondaryDsn] : [])];
+  const transport =
+    routes.length > 1 ? makeMultiplexedTransport(makeNodeTransport, () => routes) : undefined;
+
   Sentry.init({
     dsn,
     environment: process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || "development",
     release: process.env.SENTRY_RELEASE,
     tracesSampleRate,
+    transport,
     // Suppress the default server_name. Passing an empty string is NOT
     // enough — Sentry treats it as falsy and falls back to
     // `SENTRY_NAME` env / `os.hostname()`. `includeServerName: false` is
@@ -74,6 +89,7 @@ export function initSentry(): void {
     {
       environment: process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || "development",
       tracesSampleRate,
+      destinations: routes.length,
     },
     "Sentry initialized",
   );

--- a/packages/frontend/src/lib/sentry.ts
+++ b/packages/frontend/src/lib/sentry.ts
@@ -8,6 +8,7 @@
  */
 
 import * as Sentry from "@sentry/react";
+import { makeFetchTransport, makeMultiplexedTransport } from "@sentry/react";
 
 let initialized = false;
 
@@ -29,6 +30,9 @@ export interface CaptureContext {
  *
  * Reads:
  * - `VITE_SENTRY_DSN`: Project DSN. Required; if missing, initialization is skipped.
+ * - `VITE_SENTRY_SECONDARY_DSN`: Optional additional DSN. When set, every
+ *   event is sent to BOTH DSNs via a multiplexed transport — useful for A/B
+ *   comparing error-tracking backends (e.g. GlitchTip vs Sentry vs Bugsink).
  * - `VITE_SENTRY_ENVIRONMENT`: Environment tag (falls back to `MODE`).
  * - `VITE_SENTRY_TRACES_SAMPLE_RATE`: Float in `[0, 1]`. Defaults to `0`.
  * - `VITE_SENTRY_RELEASE`: Release identifier. Optional.
@@ -45,12 +49,20 @@ export function initSentry(): void {
     env.VITE_SENTRY_TRACES_SAMPLE_RATE as string | undefined,
   );
 
+  // Fan-out to a second backend when configured. Each destination keeps its
+  // own retry queue, so a slow secondary does not block primary delivery.
+  const secondaryDsn = env.VITE_SENTRY_SECONDARY_DSN as string | undefined;
+  const routes = [dsn, ...(secondaryDsn ? [secondaryDsn] : [])];
+  const transport =
+    routes.length > 1 ? makeMultiplexedTransport(makeFetchTransport, () => routes) : undefined;
+
   Sentry.init({
     dsn,
     environment:
       (env.VITE_SENTRY_ENVIRONMENT as string | undefined) || (env.MODE as string) || "development",
     release: env.VITE_SENTRY_RELEASE as string | undefined,
     tracesSampleRate,
+    transport,
     sendDefaultPii: false,
     beforeSend(event) {
       // Drop request bodies, cookies, headers, and query strings to minimize


### PR DESCRIPTION
Closes #219

## Summary

Adds optional fan-out to a second error-tracking backend. Set `SENTRY_SECONDARY_DSN` (or `VITE_SENTRY_SECONDARY_DSN` for the frontend) and every event is sent to both DSNs via Sentry's `makeMultiplexedTransport`.

Useful when comparing self-hosted Sentry-compatible backends (GlitchTip / Bugsink / Sentry SaaS) without running multiple SDK initialisations.

## Test plan

- [x] `bun run typecheck` + `bun run lint` clean
- [x] `bun test:unit` 1012/1012 pass
- [ ] Verify on prod with both DSNs set (GlitchTip + Bugsink), confirm both receive the same captured event


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Sentry エラートラッキングサービスで、複数の送信先へ同時にイベントを送信できるようになりました。環境変数でセカンダリ DSN を指定することで、エラーを複数のバックエンドに並行して送信可能です。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Love-Rox/rox/pull/220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->