### PR TITLE
chore: bump version to 2026.6.0

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -206,6 +206,17 @@ jobs:
             echo "| Waku Rox (Frontend) | \`${{ steps.pkg_versions.outputs.frontend_version }}\` |"
             echo "| Shared | \`${{ steps.pkg_versions.outputs.shared_version }}\` |"
             echo ""
+
+            # Optional per-version upgrade notes. If docs/release-notes/<tag>.md
+            # exists, prepend it as an "Upgrade Notes" section. Absent file = no-op.
+            NOTES_FILE="docs/release-notes/${CURRENT_TAG}.md"
+            if [ -f "$NOTES_FILE" ]; then
+              echo "## ⚠️ Upgrade Notes"
+              echo ""
+              cat "$NOTES_FILE"
+              echo ""
+            fi
+
             echo "## What's Changed"
             echo ""
 

--- a/docs/release-notes/v2026.6.0.md
+++ b/docs/release-notes/v2026.6.0.md
@@ -1,0 +1,24 @@
+This release is a maintenance + toolchain release. **No database migrations and no breaking API changes** — pulling the new version and reinstalling dependencies is enough.
+
+```bash
+git pull origin main
+bun install --frozen-lockfile
+bun run build
+```
+
+### TypeScript 7 (RC) toolchain
+
+- The workspace now builds and type-checks with **TypeScript `7.0.1-rc`**, the native (Go) compiler. The `tsc` command is unchanged. This affects contributors and anyone building from source — runtime behavior is unaffected.
+- **It is still an RC.** If you maintain a fork, run your full CI before relying on it in production.
+- **Editor setup:** to use TS7 in VS Code / JetBrains, point the workspace TypeScript version at `node_modules/typescript/lib`.
+- **TypeDoc** does not support TS7 yet, so API-doc generation runs from an isolated install pinned to TypeScript 6 under `tools/apidocs/`. To build docs locally, run `bun run typedoc:install` once, then `bun run typedoc`.
+- `ioredis` is pinned to a single version (`5.11.1`) via `overrides` to dedupe with BullMQ. If you adjust dependencies, keep this override in place.
+
+### Dependency refresh
+
+- All dependencies were updated to their latest versions (React 19.2.7, Hono 4.12.26, `@lingui/*` 6.4.0, `@sentry/*` 10.59.0, BullMQ 5.79.0, pg 8.22.0, sharp 0.35.2, Vite 8.0.16, Waku 1.0.0-beta.3, and more). A clean `bun install --frozen-lockfile` is recommended after pulling.
+
+### Optional: multiplexed Sentry transport
+
+- New **optional** environment variables `SENTRY_SECONDARY_DSN` / `VITE_SENTRY_SECONDARY_DSN`. When set, every event is delivered to **both** the primary and the secondary DSN via a multiplexed transport (each destination retries independently) — handy for comparing Sentry / GlitchTip / Bugsink side by side.
+- Fully backward compatible: leave them unset and behavior is identical to before.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rox",
-  "version": "2026.5.1",
+  "version": "2026.6.0",
   "license": "AGPL-3.0-only",
   "devDependencies": {
     "@playwright/test": "^1.61.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hono_rox",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waku_rox",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shared",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
## 概要

リリース `v2026.6.0`(安定版 minor)へのバージョンバンプです。

| コンポーネント | 旧 | 新 |
|---|---|---|
| Rox (Project, CalVer) | 2026.5.1 | **2026.6.0** |
| Hono Rox / Waku Rox / Shared (SemVer) | 1.7.0 | **1.8.0** |

## 含まれる主な変更(前回リリース 2026.5.1 以降)

- chore(deps): 依存パッケージ全更新 + TypeScript 7 (RC) 移行 (#228)
- feat: multiplexed Sentry transport (#220)
- ci: RELEASE_PAT ワークフロー (#218) / actions/checkout 6.0.3 (#223)

## リリースノート対応

- `docs/release-notes/v2026.6.0.md` を追加(TS7 RC ツールチェーン、TypeDoc 隔離、依存更新、Sentry secondary DSN の注意事項)
- `auto-tag.yml` を拡張し、`docs/release-notes/<tag>.md` があれば自動生成リリース本文に **Upgrade Notes** セクションとして取り込むようにしました(ファイルが無ければ従来通り no-op)

マージ後、別途 `dev → main` のリリースPRを作成します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)