### PR TITLE
docs(readme): TS7・ツールチェーンに合わせて古い記載を更新

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -19,8 +19,8 @@
     <img src="https://img.shields.io/github/v/release/Love-Rox/rox?include_prereleases&color=green" alt="Release" />
   </a>
   <img src="https://img.shields.io/badge/runtime-Bun-f9f1e1?logo=bun&logoColor=black" alt="Bun" />
-  <img src="https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white" alt="TypeScript" />
-  <img src="https://img.shields.io/badge/tests-800%2B-brightgreen" alt="Tests" />
+  <img src="https://img.shields.io/badge/TypeScript-7.x-3178C6?logo=typescript&logoColor=white" alt="TypeScript" />
+  <img src="https://img.shields.io/badge/tests-1000%2B-brightgreen" alt="Tests" />
 </p>
 
 <p align="center">
@@ -151,8 +151,8 @@ rox/
 | `bun run dev` | 全ての開発サーバーを起動 |
 | `bun run build` | 全てのパッケージをビルド |
 | `bun run test` | テストを実行 |
-| `bun run lint` | oxlintでコードをリント |
-| `bun run format` | oxlintでコードをフォーマット |
+| `bun run lint` | vp (oxc) でコードをリント |
+| `bun run format` | vp (oxc) でコードをフォーマット |
 | `bun run typecheck` | 全パッケージの型チェック |
 | `bun run db:generate` | データベースマイグレーションを生成 |
 | `bun run db:migrate` | データベースマイグレーションを実行 |

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
     <img src="https://img.shields.io/github/v/release/Love-Rox/rox?include_prereleases&color=green" alt="Release" />
   </a>
   <img src="https://img.shields.io/badge/runtime-Bun-f9f1e1?logo=bun&logoColor=black" alt="Bun" />
-  <img src="https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white" alt="TypeScript" />
-  <img src="https://img.shields.io/badge/tests-800%2B-brightgreen" alt="Tests" />
+  <img src="https://img.shields.io/badge/TypeScript-7.x-3178C6?logo=typescript&logoColor=white" alt="TypeScript" />
+  <img src="https://img.shields.io/badge/tests-1000%2B-brightgreen" alt="Tests" />
 </p>
 
 <p align="center">
@@ -151,8 +151,8 @@ rox/
 | `bun run dev` | Start all development servers |
 | `bun run build` | Build all packages |
 | `bun run test` | Run tests |
-| `bun run lint` | Lint code with oxlint |
-| `bun run format` | Format code with oxlint |
+| `bun run lint` | Lint code with vp (oxc) |
+| `bun run format` | Format code with vp (oxc) |
 | `bun run typecheck` | Type check all packages |
 | `bun run db:generate` | Generate database migrations |
 | `bun run db:migrate` | Run database migrations |


### PR DESCRIPTION
## 概要

README の古い情報を現状に合わせて更新します。

- TypeScript バッジ `5.x` → **`7.x`**(ネイティブコンパイラへ移行済み)
- テストバッジ `800+` → **`1000+`**(現在 1012 ユニットテスト)
- スクリプト説明: `oxlint` → **`vp (oxc)`**(lint / format)

README.md / README.ja.md の両方を更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)