### PR TITLE
chore(release): v2026.7.0-rc.1 (deck slide fix + version bump)

### DIFF
--- a/docs/release-notes/v2026.7.0-rc.1.md
+++ b/docs/release-notes/v2026.7.0-rc.1.md
@@ -1,0 +1,27 @@
+> **This is a release candidate (`-rc.1`).** Feature-complete and tested, but please validate in staging before relying on it in production.
+
+This release adds an **optional time-series charts subsystem** (with optional TimescaleDB acceleration) and fixes a deck rendering glitch. **One database migration is included.**
+
+```bash
+git pull origin main
+bun install --frozen-lockfile
+bun run db:migrate    # applies migration 0014
+bun run build
+```
+
+### Database migration (action required)
+
+- Migration **0014** adds the `chart_snapshots` table used by the charts subsystem, and also creates the previously-unmigrated `plugin_configs` table (guarded with `IF NOT EXISTS`, so it is safe regardless of current state).
+- No data changes to existing tables; no breaking API changes.
+
+### Time-series charts subsystem (optional, opt-in)
+
+- New optional subsystem that records periodic snapshots of instance metrics (users, notes, active users, federation, drive) and serves them through Misskey-compatible endpoints: `GET /api/charts/{users,notes,active-users,federation,drive}` (`span=hour|day`, `limit`, `until`). A new **Admin → Dashboard** page visualizes them.
+- **Disabled by default.** Enable with environment variables:
+  - `CHARTS_ENABLED=true|false` (default `false`) — turns the whole subsystem on/off. When off, behavior is identical to before: the API returns `{ enabled: false }` and no collector runs.
+  - `CHARTS_BACKEND=auto|postgres|timescale` (default `auto`) — `auto` detects the `timescaledb` extension at startup and uses it when present, otherwise falls back to plain PostgreSQL.
+- **TimescaleDB is optional and not a separate `DB_TYPE`.** It is a PostgreSQL extension; the same `DB_TYPE=postgres` path is used. When present, the `chart_snapshots` table is promoted to a hypertable with compression (30 days) and retention (400 days) policies automatically. A `timescaledb` Docker Compose profile is provided for those who want it.
+
+### Deck: fixed momentary horizontal slide on appear
+
+- The deck (multi-column) view no longer briefly slides to the right when it appears. The horizontal scroll container previously used smooth scroll behavior, which animated the on-mount scroll-position reset. Deck horizontal scrolling is now instant. No action required.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rox",
-  "version": "2026.6.0",
+  "version": "2026.7.0-rc.1",
   "license": "AGPL-3.0-only",
   "devDependencies": {
     "@playwright/test": "^1.61.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hono_rox",
-  "version": "1.8.0",
+  "version": "1.9.0-rc.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waku_rox",
-  "version": "1.8.0",
+  "version": "1.9.0-rc.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/frontend/src/components/deck/DeckLayout.tsx
+++ b/packages/frontend/src/components/deck/DeckLayout.tsx
@@ -246,9 +246,17 @@ export function DeckLayout({ showAddColumn = true, showProfileSwitcher = true }:
               items={columns.map((col) => col.id)}
               strategy={horizontalListSortingStrategy}
             >
+              {/*
+                NOTE: do not add `scroll-smooth` here. With smooth scroll
+                behavior, the programmatic `scrollLeft = 0` reset (and the
+                snap-mandatory layout settling) on mount/profile change is
+                animated, which makes the deck visibly slide to the right for a
+                moment on appear. Horizontal deck scrolling is intentionally
+                instant.
+              */}
               <div
                 ref={scrollContainerRef}
-                className="flex h-full overflow-x-auto overflow-y-hidden snap-x snap-mandatory scroll-smooth gap-1 p-2"
+                className="flex h-full overflow-x-auto overflow-y-hidden snap-x snap-mandatory gap-1 p-2"
                 style={{ scrollbarWidth: "thin" }}
               >
                 {columns.map((column) => (

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shared",
-  "version": "1.8.0",
+  "version": "1.9.0-rc.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
## v2026.7.0-rc.1 リリース準備

dev → main リリースに向けた最終調整 PR(release/v2026.7.0-rc.1 → dev)。

### 含まれる変更
- **デッキの横スライド修正**: `DeckLayout.tsx` の横スクロールコンテナから `scroll-smooth` を除去。マウント/プロフィール変更時の `scrollLeft=0` 補正(と snap-mandatory のレイアウト確定)がアニメーション化されて「一瞬右へスライド」する現象を解消。横スクロールは即時に。
- **バージョンバンプ**: root `2026.7.0-rc.1` / packages `1.9.0-rc.1`。
- **リリースノート**: `docs/release-notes/v2026.7.0-rc.1.md`(auto-tag が Upgrade Notes として本文に取り込む)。

### このRCの主な内容(直近 dev マージ分含む)
- オプションの時系列チャート統計サブシステム + TimescaleDB 任意対応(PR #235)
- デッキの横スライド修正

### 注意
- DB マイグレーション **0014** が含まれます(`chart_snapshots` + 既存取りこぼしの `plugin_configs`)。更新時は `bun run db:migrate` が必要。
- チャート機能は既定で無効(`CHARTS_ENABLED=false`)。

https://claude.ai/code/session_01F47UqfYk5iRxDuokkyyzLr
