### PR TITLE
fix(docker): bun 1.3 base + bundled migrate runner

### DIFF
--- a/deploy/k8s/rox/30-backend.yaml
+++ b/deploy/k8s/rox/30-backend.yaml
@@ -47,7 +47,7 @@ spec:
         - name: migrate
           image: ghcr.io/love-rox/rox-backend:dev
           workingDir: /app/packages/backend
-          command: ["bun", "run", "src/db/migrate.ts"]
+          command: ["bun", "run", "dist/migrate.js"]
           envFrom:
             - secretRef:
                 name: rox-config

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -4,14 +4,16 @@
 # ============================================
 # Stage 1: Build
 # ============================================
-FROM oven/bun:1.1-alpine AS builder
+FROM oven/bun:1.3-alpine AS builder
 
 WORKDIR /app
 
-# Copy package files
+# Copy package files. All workspace package.json files are required so
+# `bun install --frozen-lockfile` can validate the workspace lockfile.
 COPY package.json bun.lock ./
 COPY packages/backend/package.json ./packages/backend/
 COPY packages/shared/package.json ./packages/shared/
+COPY packages/frontend/package.json ./packages/frontend/
 
 # Install dependencies
 RUN bun install --frozen-lockfile
@@ -25,14 +27,18 @@ COPY tsconfig.json ./
 WORKDIR /app/packages/shared
 RUN bun run build
 
-# Build backend
+# Build backend (app entrypoint)
 WORKDIR /app/packages/backend
 RUN bun run build
+
+# Also bundle the migration runner so it can run standalone (deps inlined),
+# without relying on the workspace node_modules layout at runtime.
+RUN bun build src/db/migrate.ts --outdir dist --target bun
 
 # ============================================
 # Stage 2: Production
 # ============================================
-FROM oven/bun:1.1-alpine AS production
+FROM oven/bun:1.3-alpine AS production
 
 # Install security updates and required packages
 RUN apk update && apk upgrade && \
@@ -53,11 +59,9 @@ COPY --from=builder /app/packages/shared/dist ./packages/shared/dist
 COPY --from=builder /app/packages/shared/package.json ./packages/shared/
 COPY --from=builder /app/package.json ./
 
-# Include the migration runner and SQL migrations so an init container can run
-# `bun run src/db/migrate.ts` against the database before the app starts.
-# migrate.ts only depends on drizzle-orm + pg (already in node_modules), so it
-# runs standalone without the rest of the source tree.
-COPY --from=builder /app/packages/backend/src/db/migrate.ts ./packages/backend/src/db/migrate.ts
+# Include the SQL migrations so an init container can run the bundled migration
+# runner (dist/migrate.js, already included with dist above) against the
+# database before the app starts. The migrator reads these SQL files at runtime.
 COPY --from=builder /app/packages/backend/drizzle ./packages/backend/drizzle
 
 # Create uploads directory with proper permissions

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -4,14 +4,16 @@
 # ============================================
 # Stage 1: Build
 # ============================================
-FROM oven/bun:1.1-alpine AS builder
+FROM oven/bun:1.3-alpine AS builder
 
 WORKDIR /app
 
-# Copy package files
+# Copy package files. All workspace package.json files are required so
+# `bun install --frozen-lockfile` can validate the workspace lockfile.
 COPY package.json bun.lock ./
 COPY packages/frontend/package.json ./packages/frontend/
 COPY packages/shared/package.json ./packages/shared/
+COPY packages/backend/package.json ./packages/backend/
 
 # Install dependencies
 RUN bun install --frozen-lockfile
@@ -32,7 +34,7 @@ RUN bun run build
 # ============================================
 # Stage 2: Production
 # ============================================
-FROM oven/bun:1.1-alpine AS production
+FROM oven/bun:1.3-alpine AS production
 
 # Install security updates
 RUN apk update && apk upgrade && \


### PR DESCRIPTION
イメージビルド失敗の修正。

## 原因
- ベースイメージ `oven/bun:1.1-alpine` が古く、テキスト形式 `bun.lock`(bun ≥1.2)を読めず `bun install --frozen-lockfile` が失敗。
- ワークスペースの全 package.json が無いと frozen-lockfile が検証できない。
- 生 `src/db/migrate.ts` 実行が hoist された node_modules から `drizzle-orm` を解決できなかった。

## 修正
- 両 Dockerfile を `oven/bun:1.3-alpine` に更新(builder/production)。
- install 前に 3 ワークスペースの package.json を全て COPY。
- migrate を bundle 化(`dist/migrate.js`、依存 inline)。initContainer を `bun run dist/migrate.js` に変更。

## 検証(ローカル e2e)
- backend/frontend 両イメージのビルド成功。
- `timescale/timescaledb:2.17.2-pg16` に対しマイグレーション成功(32 tables / chart_snapshots)。
- `create_hypertable('chart_snapshots','bucket')` 成功。

https://claude.ai/code/session_01F47UqfYk5iRxDuokkyyzLr