### PR TITLE
fix(docker): Debian base + production NODE_ENV + JSON logs

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -4,7 +4,7 @@
 # ============================================
 # Stage 1: Build
 # ============================================
-FROM oven/bun:1.3-alpine AS builder
+FROM oven/bun:1.3 AS builder
 
 WORKDIR /app
 
@@ -23,11 +23,14 @@ COPY packages/backend ./packages/backend
 COPY packages/shared ./packages/shared
 COPY tsconfig.json ./
 
-# Build shared package
-WORKDIR /app/packages/shared
-RUN bun run build
+# Set production AFTER install (so devDeps are available for the build) and
+# BEFORE bundling: `bun build` inlines process.env.NODE_ENV at build time, so it
+# must be "production" here for the bundle to behave as production at runtime.
+ENV NODE_ENV=production
 
-# Build backend (app entrypoint)
+# Build backend (app entrypoint). The shared package is consumed from source
+# (its package.json `main` points at src/index.ts) and bun bundles it into the
+# output, so there is no separate shared build/dist step.
 WORKDIR /app/packages/backend
 RUN bun run build
 
@@ -38,16 +41,17 @@ RUN bun build src/db/migrate.ts --outdir dist --target bun
 # ============================================
 # Stage 2: Production
 # ============================================
-FROM oven/bun:1.3-alpine AS production
+FROM oven/bun:1.3 AS production
 
-# Install security updates and required packages
-RUN apk update && apk upgrade && \
-    apk add --no-cache curl && \
-    rm -rf /var/cache/apk/*
+# Install security updates and required packages (Debian/glibc base so the
+# prebuilt sharp binaries load reliably).
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends curl && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create non-root user for security
-RUN addgroup -g 1001 -S rox && \
-    adduser -S -D -H -u 1001 -s /sbin/nologin -G rox rox
+RUN groupadd -g 1001 rox && \
+    useradd -r -u 1001 -g rox -s /usr/sbin/nologin rox
 
 WORKDIR /app
 
@@ -55,7 +59,6 @@ WORKDIR /app
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/packages/backend/dist ./packages/backend/dist
 COPY --from=builder /app/packages/backend/package.json ./packages/backend/
-COPY --from=builder /app/packages/shared/dist ./packages/shared/dist
 COPY --from=builder /app/packages/shared/package.json ./packages/shared/
 COPY --from=builder /app/package.json ./
 

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -4,7 +4,7 @@
 # ============================================
 # Stage 1: Build
 # ============================================
-FROM oven/bun:1.3-alpine AS builder
+FROM oven/bun:1.3 AS builder
 
 WORKDIR /app
 
@@ -23,26 +23,28 @@ COPY packages/frontend ./packages/frontend
 COPY packages/shared ./packages/shared
 COPY tsconfig.json ./
 
-# Build shared package
-WORKDIR /app/packages/shared
-RUN bun run build
+# Set production AFTER install (so devDeps are available for the build) and
+# BEFORE building, so any build-time NODE_ENV inlining reflects production.
+ENV NODE_ENV=production
 
-# Build frontend (Waku)
+# Build frontend (Waku). The shared package is consumed from source (its
+# package.json `main` points at src/index.ts) and the bundler inlines it, so
+# there is no separate shared build/dist step.
 WORKDIR /app/packages/frontend
 RUN bun run build
 
 # ============================================
 # Stage 2: Production
 # ============================================
-FROM oven/bun:1.3-alpine AS production
+FROM oven/bun:1.3 AS production
 
-# Install security updates
-RUN apk update && apk upgrade && \
-    rm -rf /var/cache/apk/*
+# Install security updates (Debian/glibc base, consistent with the backend)
+RUN apt-get update && apt-get upgrade -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create non-root user for security
-RUN addgroup -g 1001 -S rox && \
-    adduser -S -D -H -u 1001 -s /sbin/nologin -G rox rox
+RUN groupadd -g 1001 rox && \
+    useradd -r -u 1001 -g rox -s /usr/sbin/nologin rox
 
 WORKDIR /app
 
@@ -51,7 +53,6 @@ COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/packages/frontend/dist ./packages/frontend/dist
 COPY --from=builder /app/packages/frontend/package.json ./packages/frontend/
 COPY --from=builder /app/packages/frontend/start.ts ./packages/frontend/
-COPY --from=builder /app/packages/shared/dist ./packages/shared/dist
 COPY --from=builder /app/packages/shared/package.json ./packages/shared/
 COPY --from=builder /app/package.json ./
 

--- a/packages/backend/src/lib/logger.ts
+++ b/packages/backend/src/lib/logger.ts
@@ -70,7 +70,10 @@ function createLoggerConfig(config: LoggerConfig = {}): pino.LoggerOptions {
  */
 function createTransport(config: LoggerConfig = {}): pino.TransportSingleOptions | undefined {
   const isProduction = process.env.NODE_ENV === "production";
-  const pretty = config.pretty ?? true;
+  // Pretty printing (via the pino-pretty transport) is for development only.
+  // In production we emit structured JSON, which also avoids requiring the
+  // pino-pretty module at runtime (it isn't bundled into the production image).
+  const pretty = config.pretty ?? !isProduction;
 
   if (pretty) {
     return {


### PR DESCRIPTION
コンテナイメージの実行時修正(ビルド&起動検証で発見)。

- ベースを `oven/bun:1.3`(Debian/glibc)へ。alpine では sharp 等のネイティブバイナリ相性問題が起きるため。apt/ユーザ作成も変換。
- builder で `ENV NODE_ENV=production`(install 後・build 前)。bun build はビルド時の NODE_ENV をインライン化するため、未設定だと本番でも debug/pino-pretty が焼き込まれる。
- logger: pino-pretty は開発のみ。本番は JSON。
- shared はソース消費(main→src)なので shared ビルド/コピーを廃止(bundler が inline)。

amd64(本番=Ubuntu glibc amd64)で CI 検証。arm64 ローカルは arch 固有の差異のみ。

https://claude.ai/code/session_01F47UqfYk5iRxDuokkyyzLr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 本番環境向けのビルド・実行設定を見直し、より安定した起動と配布になるよう改善しました。
  * 本番ではデバッグ向けの整形ログが自動で有効にならないようになり、出力がより適切になりました。
  * フロントエンド/バックエンドの配布物の構成を整理し、不要な生成物を含めないようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->