### PR TITLE
fix(docker): hoisted bun linker for bundled native deps (sharp)

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,10 @@
+# Use the hoisted (flat) node_modules layout instead of bun's isolated layout.
+#
+# The production container images bundle the app with `bun build` and then run
+# the bundle against a node_modules copied from the build stage. Native deps
+# (e.g. sharp -> @img/sharp-linux-x64) are required dynamically at runtime, and
+# the isolated `.bun` symlink layout does not survive the multi-stage COPY in a
+# way the bundle can resolve. A hoisted, flat node_modules is portable across
+# the COPY and keeps every dependency resolvable from the top level.
+[install]
+linker = "hoisted"

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -10,7 +10,7 @@ WORKDIR /app
 
 # Copy package files. All workspace package.json files are required so
 # `bun install --frozen-lockfile` can validate the workspace lockfile.
-COPY package.json bun.lock ./
+COPY package.json bun.lock bunfig.toml ./
 COPY packages/backend/package.json ./packages/backend/
 COPY packages/shared/package.json ./packages/shared/
 COPY packages/frontend/package.json ./packages/frontend/
@@ -55,7 +55,10 @@ RUN groupadd -g 1001 rox && \
 
 WORKDIR /app
 
-# Copy built files and dependencies
+# Copy built files and dependencies. With the hoisted node_modules linker
+# (bunfig.toml), this single flat node_modules contains every dependency —
+# including native ones like sharp's `@img/sharp-linux-x64`, which the bundle
+# resolves at runtime.
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/packages/backend/dist ./packages/backend/dist
 COPY --from=builder /app/packages/backend/package.json ./packages/backend/

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -10,7 +10,7 @@ WORKDIR /app
 
 # Copy package files. All workspace package.json files are required so
 # `bun install --frozen-lockfile` can validate the workspace lockfile.
-COPY package.json bun.lock ./
+COPY package.json bun.lock bunfig.toml ./
 COPY packages/frontend/package.json ./packages/frontend/
 COPY packages/shared/package.json ./packages/shared/
 COPY packages/backend/package.json ./packages/backend/


### PR DESCRIPTION
backend Pod が `Could not load the sharp module using the linux-x64 runtime` でクラッシュ。bun の isolated node_modules(.bun + symlink)はマルチステージ COPY 後にバンドル実行時のネイティブ依存(sharp の @img/sharp-linux-x64)を解決できない。

- `bunfig.toml` に `[install] linker = "hoisted"` を追加(フラットで COPY 可搬な node_modules)。
- 両 Dockerfile の install 前に bunfig.toml を COPY。

amd64 CI でビルド成功。クラスタ(amd64)で起動検証中。

https://claude.ai/code/session_01F47UqfYk5iRxDuokkyyzLr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * コンテナ内での依存関係解決を安定化し、ビルド後もアプリが正しく起動しやすくなりました。
  * フロントエンド・バックエンドの両方で、設定ファイルを含めた依存インストールに対応しました。
  * ネイティブ依存を含む環境でも、より一貫した動作になるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->