### PR TITLE
fix(k8s): imagePullPolicy Always for app deployments

### DIFF
--- a/deploy/k8s/rox/30-backend.yaml
+++ b/deploy/k8s/rox/30-backend.yaml
@@ -46,6 +46,7 @@ spec:
         # Apply DB migrations before the app starts (idempotent; safe per boot).
         - name: migrate
           image: ghcr.io/love-rox/rox-backend:dev
+          imagePullPolicy: Always
           workingDir: /app/packages/backend
           command: ["bun", "run", "dist/migrate.js"]
           envFrom:
@@ -60,6 +61,7 @@ spec:
       containers:
         - name: rox-backend
           image: ghcr.io/love-rox/rox-backend:dev
+          imagePullPolicy: Always
           ports:
             - containerPort: 3000
           envFrom:

--- a/deploy/k8s/rox/40-frontend.yaml
+++ b/deploy/k8s/rox/40-frontend.yaml
@@ -44,6 +44,7 @@ spec:
       containers:
         - name: rox-frontend
           image: ghcr.io/love-rox/rox-frontend:dev
+          imagePullPolicy: Always
           ports:
             - containerPort: 3001
           envFrom:


### PR DESCRIPTION
moving タグ :dev 追従のため imagePullPolicy: Always。IfNotPresent だと古いキャッシュ :dev を再利用してしまう。

https://claude.ai/code/session_01F47UqfYk5iRxDuokkyyzLr