### PR TITLE
Release v2026.7.0-rc.2

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,77 @@
+name: Build & Push Images
+
+# Build the backend and frontend container images and push them to GHCR.
+#
+# Tagging:
+#   - push to dev    -> :dev    + :sha-<short>   (the tag the K3S deployment tracks via keel)
+#   - push to main   -> :main   + :sha-<short>
+#   - push tag v*    -> :<version> (e.g. v2026.7.0-rc.1) + :sha-<short>
+#
+# Note: we intentionally do NOT publish a moving `:latest` tag. The cluster
+# tracks the explicit `:dev` tag, and avoiding `:latest` sidesteps the tag
+# resolution ambiguity that previously affected keel on the ikaskey instance.
+
+on:
+  push:
+    branches: [dev, main]
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAMESPACE: love-rox
+
+jobs:
+  build:
+    name: Build ${{ matrix.component }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - component: backend
+            dockerfile: docker/Dockerfile.backend
+            image: rox-backend
+          - component: frontend
+            dockerfile: docker/Dockerfile.frontend
+            image: rox-frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.component }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.component }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -73,5 +73,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ matrix.component }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.component }}
+          provenance: false

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,10 @@
+# Use the hoisted (flat) node_modules layout instead of bun's isolated layout.
+#
+# The production container images bundle the app with `bun build` and then run
+# the bundle against a node_modules copied from the build stage. Native deps
+# (e.g. sharp -> @img/sharp-linux-x64) are required dynamically at runtime, and
+# the isolated `.bun` symlink layout does not survive the multi-stage COPY in a
+# way the bundle can resolve. A hoisted, flat node_modules is portable across
+# the COPY and keeps every dependency resolvable from the top level.
+[install]
+linker = "hoisted"

--- a/deploy/k8s/rox/00-namespace.yaml
+++ b/deploy/k8s/rox/00-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rox
+  labels:
+    app.kubernetes.io/part-of: rox

--- a/deploy/k8s/rox/10-timescaledb.yaml
+++ b/deploy/k8s/rox/10-timescaledb.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rox-timescaledb
+  namespace: rox
+  labels:
+    app: rox-timescaledb
+spec:
+  clusterIP: None
+  selector:
+    app: rox-timescaledb
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: rox-timescaledb
+  namespace: rox
+spec:
+  serviceName: rox-timescaledb
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rox-timescaledb
+  template:
+    metadata:
+      labels:
+        app: rox-timescaledb
+    spec:
+      # Pin to the sakura node: local-path storage is node-local and the
+      # production data lives on this node.
+      nodeSelector:
+        kubernetes.io/hostname: sakura
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: timescaledb
+          # TimescaleDB on PostgreSQL 16 (matches the bare-metal PG16 dump).
+          image: timescale/timescaledb:2.17.2-pg16
+          ports:
+            - containerPort: 5432
+          envFrom:
+            - secretRef:
+                name: rox-config
+          env:
+            # PGDATA in a subdir so the PVC root (with lost+found) isn't used directly.
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "rox", "-d", "rox"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: local-path
+        resources:
+          requests:
+            storage: 5Gi

--- a/deploy/k8s/rox/20-dragonfly.yaml
+++ b/deploy/k8s/rox/20-dragonfly.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rox-dragonfly
+  namespace: rox
+  labels:
+    app: rox-dragonfly
+spec:
+  selector:
+    app: rox-dragonfly
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: rox-dragonfly
+  namespace: rox
+spec:
+  serviceName: rox-dragonfly
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rox-dragonfly
+  template:
+    metadata:
+      labels:
+        app: rox-dragonfly
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: sakura
+      containers:
+        - name: dragonfly
+          image: docker.dragonflydb.io/dragonflydb/dragonfly:v1.25.1
+          args: ["--dir", "/data"]
+          ports:
+            - containerPort: 6379
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          readinessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: local-path
+        resources:
+          requests:
+            storage: 1Gi

--- a/deploy/k8s/rox/20-dragonfly.yaml
+++ b/deploy/k8s/rox/20-dragonfly.yaml
@@ -34,7 +34,11 @@ spec:
       containers:
         - name: dragonfly
           image: docker.dragonflydb.io/dragonflydb/dragonfly:v1.25.1
-          args: ["--dir", "/data"]
+          # Constrain threads/memory: Dragonfly otherwise sizes itself to the
+          # node's CPU count (requiring ~256MiB per io thread) and crashes when
+          # that exceeds the container limit. One thread + a small maxmemory is
+          # plenty for this instance's cache/queue use.
+          args: ["--dir", "/data", "--proactor_threads=1", "--maxmemory=300mb"]
           ports:
             - containerPort: 6379
           volumeMounts:

--- a/deploy/k8s/rox/25-uploads-pvc.yaml
+++ b/deploy/k8s/rox/25-uploads-pvc.yaml
@@ -1,0 +1,14 @@
+# Shared uploads volume (local storage). Written by rox-backend, served by nginx.
+# local-path is node-local + ReadWriteOnce, so both consumers are pinned to the
+# sakura node (RWO permits multiple pods on the same node).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rox-uploads
+  namespace: rox
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 10Gi

--- a/deploy/k8s/rox/30-backend.yaml
+++ b/deploy/k8s/rox/30-backend.yaml
@@ -47,7 +47,7 @@ spec:
         - name: migrate
           image: ghcr.io/love-rox/rox-backend:dev
           workingDir: /app/packages/backend
-          command: ["bun", "run", "src/db/migrate.ts"]
+          command: ["bun", "run", "dist/migrate.js"]
           envFrom:
             - secretRef:
                 name: rox-config

--- a/deploy/k8s/rox/30-backend.yaml
+++ b/deploy/k8s/rox/30-backend.yaml
@@ -46,6 +46,7 @@ spec:
         # Apply DB migrations before the app starts (idempotent; safe per boot).
         - name: migrate
           image: ghcr.io/love-rox/rox-backend:dev
+          imagePullPolicy: Always
           workingDir: /app/packages/backend
           command: ["bun", "run", "dist/migrate.js"]
           envFrom:
@@ -60,6 +61,7 @@ spec:
       containers:
         - name: rox-backend
           image: ghcr.io/love-rox/rox-backend:dev
+          imagePullPolicy: Always
           ports:
             - containerPort: 3000
           envFrom:

--- a/deploy/k8s/rox/30-backend.yaml
+++ b/deploy/k8s/rox/30-backend.yaml
@@ -1,0 +1,107 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rox-backend
+  namespace: rox
+  labels:
+    app: rox-backend
+spec:
+  selector:
+    app: rox-backend
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rox-backend
+  namespace: rox
+  annotations:
+    # keel auto-updates this deployment when the :dev tag's digest changes.
+    keel.sh/policy: force
+    keel.sh/trigger: poll
+    keel.sh/pollSchedule: "@every 3m"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: rox-backend
+  template:
+    metadata:
+      labels:
+        app: rox-backend
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: sakura
+      terminationGracePeriodSeconds: 45
+      initContainers:
+        # Apply DB migrations before the app starts (idempotent; safe per boot).
+        - name: migrate
+          image: ghcr.io/love-rox/rox-backend:dev
+          workingDir: /app/packages/backend
+          command: ["bun", "run", "src/db/migrate.ts"]
+          envFrom:
+            - secretRef:
+                name: rox-config
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+      containers:
+        - name: rox-backend
+          image: ghcr.io/love-rox/rox-backend:dev
+          ports:
+            - containerPort: 3000
+          envFrom:
+            - secretRef:
+                name: rox-config
+          env:
+            - name: NODE_ENV
+              value: production
+            - name: PORT
+              value: "3000"
+          volumeMounts:
+            - name: uploads
+              mountPath: /app/uploads
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 10"]
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            periodSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 3000
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            periodSeconds: 30
+            failureThreshold: 5
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+      volumes:
+        - name: uploads
+          persistentVolumeClaim:
+            claimName: rox-uploads

--- a/deploy/k8s/rox/40-frontend.yaml
+++ b/deploy/k8s/rox/40-frontend.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rox-frontend
+  namespace: rox
+  labels:
+    app: rox-frontend
+spec:
+  selector:
+    app: rox-frontend
+  ports:
+    - name: http
+      port: 3001
+      targetPort: 3001
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rox-frontend
+  namespace: rox
+  annotations:
+    keel.sh/policy: force
+    keel.sh/trigger: poll
+    keel.sh/pollSchedule: "@every 3m"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: rox-frontend
+  template:
+    metadata:
+      labels:
+        app: rox-frontend
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: sakura
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: rox-frontend
+          image: ghcr.io/love-rox/rox-frontend:dev
+          ports:
+            - containerPort: 3001
+          envFrom:
+            - secretRef:
+                name: rox-config
+          env:
+            - name: NODE_ENV
+              value: production
+            - name: FRONTEND_PORT
+              value: "3001"
+            - name: INTERNAL_API_URL
+              value: http://rox-backend:3000
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3001
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 100m
+              memory: 192Mi
+            limits:
+              memory: 512Mi

--- a/deploy/k8s/rox/40-frontend.yaml
+++ b/deploy/k8s/rox/40-frontend.yaml
@@ -44,6 +44,7 @@ spec:
       containers:
         - name: rox-frontend
           image: ghcr.io/love-rox/rox-frontend:dev
+          imagePullPolicy: Always
           ports:
             - containerPort: 3001
           envFrom:

--- a/deploy/k8s/rox/50-nginx.yaml
+++ b/deploy/k8s/rox/50-nginx.yaml
@@ -1,0 +1,345 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rox-nginx
+  namespace: rox
+data:
+  nginx.conf: |
+    user nginx;
+    worker_processes auto;
+    error_log /var/log/nginx/error.log warn;
+    pid /var/run/nginx.pid;
+
+    events {
+        worker_connections 1024;
+        use epoll;
+        multi_accept on;
+    }
+
+    http {
+        include /etc/nginx/mime.types;
+        default_type application/octet-stream;
+
+        log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                        '$status $body_bytes_sent "$http_referer" '
+                        '"$http_user_agent" "$http_x_forwarded_for"';
+        access_log /var/log/nginx/access.log main;
+
+        sendfile on;
+        tcp_nopush on;
+        tcp_nodelay on;
+        keepalive_timeout 65;
+        types_hash_max_size 2048;
+
+        # Resolve service names for variable-based proxy_pass (/notes/, /@user).
+        resolver 10.43.0.10 valid=30s ipv6=off;
+
+        gzip on;
+        gzip_vary on;
+        gzip_proxied any;
+        gzip_comp_level 6;
+        gzip_types text/plain text/css text/xml application/json application/javascript
+                   application/rss+xml application/atom+xml image/svg+xml
+                   application/activity+json application/ld+json;
+
+        limit_req_zone $binary_remote_addr zone=api_limit:10m rate=50r/s;
+        limit_req_zone $binary_remote_addr zone=auth_limit:10m rate=10r/m;
+        limit_req_zone $binary_remote_addr zone=inbox_zone:10m rate=10r/s;
+
+        map $http_accept $is_activitypub_request {
+            default                          0;
+            "~*application/activity\+json"   1;
+            "~*application/ld\+json"         1;
+        }
+
+        map $is_activitypub_request $notes_upstream {
+            default                          rox-frontend:3001;
+            1                                rox-backend:3000;
+        }
+
+        map $is_activitypub_request $user_profile_upstream {
+            default                          rox-frontend:3001;
+            1                                rox-backend:3000;
+        }
+
+        include /etc/nginx/conf.d/*.conf;
+    }
+  default.conf: |
+    upstream rox_backend {
+        server rox-backend:3000;
+        keepalive 64;
+    }
+
+    upstream rox_frontend {
+        server rox-frontend:3001;
+        keepalive 32;
+    }
+
+    server {
+        listen 80;
+        server_name _;
+        client_max_body_size 50M;
+
+        location ~ ^(.+)/$ {
+            return 301 $scheme://$host$1$is_args$args;
+        }
+
+        location = /api/notifications/stream {
+            proxy_pass http://rox_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 3600s;
+            proxy_read_timeout 3600s;
+            proxy_set_header Connection "";
+            chunked_transfer_encoding on;
+        }
+
+        location /api/ {
+            limit_req zone=api_limit burst=50 nodelay;
+            limit_req_status 429;
+            proxy_pass http://rox_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 120s;
+            proxy_read_timeout 120s;
+            proxy_buffering off;
+            proxy_set_header Connection "";
+        }
+
+        location /api/auth/ {
+            limit_req zone=auth_limit burst=5 nodelay;
+            proxy_pass http://rox_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 120s;
+            proxy_read_timeout 120s;
+            proxy_buffering off;
+            proxy_set_header Connection "";
+        }
+
+        location /ws/ {
+            proxy_pass http://rox_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_read_timeout 86400s;
+            proxy_send_timeout 86400s;
+            proxy_buffering off;
+        }
+
+        location ~ ^/users/[^/]+/inbox$ {
+            limit_req zone=inbox_zone burst=20 nodelay;
+            limit_req_status 429;
+            proxy_pass http://rox_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 120s;
+            proxy_read_timeout 120s;
+            proxy_buffering off;
+            proxy_set_header Connection "";
+        }
+
+        location /.well-known/ {
+            proxy_pass http://rox_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_buffering off;
+            proxy_set_header Connection "";
+        }
+
+        location /nodeinfo/ {
+            proxy_pass http://rox_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_buffering off;
+        }
+
+        location /oembed {
+            proxy_pass http://rox_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_buffering off;
+            add_header Cache-Control "public, max-age=300";
+        }
+
+        location /users/ {
+            proxy_pass http://rox_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_buffering off;
+        }
+
+        # Accept-header routing (ActivityPub vs HTML). Uses variable upstream,
+        # which requires the resolver configured in nginx.conf.
+        location /notes/ {
+            proxy_pass http://$notes_upstream;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Connection "";
+        }
+
+        location ~ ^/@[^/]+$ {
+            proxy_pass http://$user_profile_upstream;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Connection "";
+        }
+
+        location /health {
+            proxy_pass http://rox_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_buffering off;
+        }
+
+        location /uploads/ {
+            alias /app/uploads/;
+            expires 30d;
+            add_header Cache-Control "public, immutable";
+            location ~ \.(php|cgi|pl|py)$ {
+                deny all;
+            }
+        }
+
+        location / {
+            proxy_pass http://rox_frontend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_connect_timeout 120s;
+            proxy_send_timeout 120s;
+            proxy_read_timeout 120s;
+            proxy_buffer_size 16k;
+            proxy_buffers 16 16k;
+            proxy_busy_buffers_size 32k;
+        }
+
+        error_page 502 503 504 /50x.html;
+        location = /50x.html {
+            root /usr/share/nginx/html;
+            internal;
+        }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rox-nginx
+  namespace: rox
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rox-nginx
+  template:
+    metadata:
+      labels:
+        app: rox-nginx
+      annotations:
+        # Roll the nginx pod when the config changes (set by `kubectl rollout
+        # restart` after editing the ConfigMap).
+        rox.love-rox.cc/config-version: "1"
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: sakura
+      containers:
+        - name: nginx
+          image: nginx:1.27-alpine
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: nginx-conf
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+              readOnly: true
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+              readOnly: true
+            - name: uploads
+              mountPath: /app/uploads
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+      volumes:
+        - name: nginx-conf
+          configMap:
+            name: rox-nginx
+        - name: uploads
+          persistentVolumeClaim:
+            claimName: rox-uploads
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rox-nginx
+  namespace: rox
+  labels:
+    app: rox-nginx
+spec:
+  type: NodePort
+  externalTrafficPolicy: Local
+  selector:
+    app: rox-nginx
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      nodePort: 30091

--- a/deploy/k8s/rox/README.md
+++ b/deploy/k8s/rox/README.md
@@ -1,0 +1,69 @@
+# Rox on K3S
+
+Manifests for running Rox on the existing K3S cluster (control-plane
+`samurai-watch`, worker `sakura` which holds the public IP and storage),
+mirroring the ikaskey operational pattern: images on GHCR, auto-updated by
+**keel** tracking the `:dev` tag.
+
+## Components (namespace `rox`, all pinned to node `sakura`)
+
+| Manifest | Purpose |
+|----------|---------|
+| `00-namespace.yaml` | namespace `rox` |
+| `secret.example.yaml` | template for the `rox-config` secret (create the real one on the cluster) |
+| `10-timescaledb.yaml` | TimescaleDB (PG16) StatefulSet + headless Service (charts backend) |
+| `20-dragonfly.yaml` | Dragonfly (Redis-compatible) for cache/queue |
+| `25-uploads-pvc.yaml` | shared local-path PVC for uploads (backend rw, nginx ro) |
+| `30-backend.yaml` | `hono_rox` Deployment (initContainer runs migrations) + Service; keel-managed |
+| `40-frontend.yaml` | `waku_rox` Deployment + Service; keel-managed |
+| `50-nginx.yaml` | nginx reverse proxy (path + Accept-header routing) + NodePort `30091` |
+
+Auto-update: the existing cluster-wide keel (ns `ikaskey-gatekeeper`) polls the
+`:dev` images every 3 min and rolls the backend/frontend Deployments on digest
+change. The backend initContainer applies DB migrations on each boot.
+
+## Images
+
+Built and pushed by `.github/workflows/build-images.yml` on push to `dev`/`main`
+and on `v*` tags:
+
+- `ghcr.io/love-rox/rox-backend:dev`
+- `ghcr.io/love-rox/rox-frontend:dev`
+
+## First-time deploy
+
+```bash
+# On samurai-watch (control-plane). kubectl = `sudo k3s kubectl`.
+
+# 1. Namespace + secret (generate from the bare-metal /opt/rox/.env, rewriting
+#    DATABASE_URL to the in-cluster DB and adding CHARTS_*; pick a new DB password).
+kubectl apply -f 00-namespace.yaml
+kubectl -n rox create secret generic rox-config --from-env-file=./rox.env
+
+# 2. Data layer
+kubectl apply -f 10-timescaledb.yaml -f 20-dragonfly.yaml -f 25-uploads-pvc.yaml
+kubectl -n rox rollout status statefulset/rox-timescaledb
+
+# 3. Data migration from bare-metal (~14 MB):
+#    pg_dump -Fc the bare-metal rox DB, then restore into rox-timescaledb,
+#    and rsync the uploads/ dir into the rox-uploads PVC. (See migration notes.)
+
+# 4. App + proxy
+kubectl apply -f 30-backend.yaml -f 40-frontend.yaml -f 50-nginx.yaml
+kubectl -n rox get pods
+
+# 5. Smoke test via NodePort (before cutover):
+#    curl -H 'Host: rox.love-rox.cc' http://<sakura-internal-ip>:30091/health
+```
+
+## Cutover (Cloudflare)
+
+Add an ingress rule to the host cloudflared on `samurai-watch`
+(`rox.love-rox.cc -> http://10.10.0.1:30091`), reload cloudflared, point the DNS
+record at the tunnel, verify `https://rox.love-rox.cc`, then stop the bare-metal
+`rox.service` and its nginx. Keep the bare-metal DB as a hot rollback.
+
+## Notes
+
+- The real `rox-config` secret is **never committed**; only `secret.example.yaml`.
+- Mirror of these manifests lives on the cluster at `/srv/k3s-manifests/rox/`.

--- a/deploy/k8s/rox/secret.example.yaml
+++ b/deploy/k8s/rox/secret.example.yaml
@@ -1,0 +1,38 @@
+# Example secret for the Rox namespace.
+#
+# DO NOT commit the real secret. On the cluster, generate it from the existing
+# bare-metal /opt/rox/.env (rewriting DATABASE_URL to point at the in-cluster
+# rox-timescaledb service and adding the CHARTS_* keys). Example:
+#
+#   kubectl -n rox create secret generic rox-config \
+#     --from-env-file=/path/to/rox.env
+#
+# The env file must contain at least the keys below. POSTGRES_PASSWORD must match
+# the password embedded in DATABASE_URL (the in-cluster DB is fresh, so pick a
+# new strong password and use it in both places).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rox-config
+  namespace: rox
+type: Opaque
+stringData:
+  # Database (in-cluster TimescaleDB)
+  DB_TYPE: postgres
+  DATABASE_URL: postgresql://rox:CHANGE_ME@rox-timescaledb:5432/rox
+  POSTGRES_USER: rox
+  POSTGRES_PASSWORD: CHANGE_ME
+  POSTGRES_DB: rox
+  # Cache / queue
+  DRAGONFLY_URL: redis://rox-dragonfly:6379
+  # Application
+  URL: https://rox.love-rox.cc
+  STORAGE_TYPE: local
+  LOCAL_STORAGE_PATH: /app/uploads
+  ENABLE_REGISTRATION: "false"
+  SESSION_EXPIRY_DAYS: "30"
+  # Charts subsystem (TimescaleDB auto-detected)
+  CHARTS_ENABLED: "true"
+  CHARTS_BACKEND: auto
+  # ...plus any other secrets carried over from the bare-metal .env
+  # (session secrets, S3_*, SENTRY_DSN, etc.)

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -4,14 +4,16 @@
 # ============================================
 # Stage 1: Build
 # ============================================
-FROM oven/bun:1.1-alpine AS builder
+FROM oven/bun:1.3-alpine AS builder
 
 WORKDIR /app
 
-# Copy package files
+# Copy package files. All workspace package.json files are required so
+# `bun install --frozen-lockfile` can validate the workspace lockfile.
 COPY package.json bun.lock ./
 COPY packages/backend/package.json ./packages/backend/
 COPY packages/shared/package.json ./packages/shared/
+COPY packages/frontend/package.json ./packages/frontend/
 
 # Install dependencies
 RUN bun install --frozen-lockfile
@@ -25,14 +27,18 @@ COPY tsconfig.json ./
 WORKDIR /app/packages/shared
 RUN bun run build
 
-# Build backend
+# Build backend (app entrypoint)
 WORKDIR /app/packages/backend
 RUN bun run build
+
+# Also bundle the migration runner so it can run standalone (deps inlined),
+# without relying on the workspace node_modules layout at runtime.
+RUN bun build src/db/migrate.ts --outdir dist --target bun
 
 # ============================================
 # Stage 2: Production
 # ============================================
-FROM oven/bun:1.1-alpine AS production
+FROM oven/bun:1.3-alpine AS production
 
 # Install security updates and required packages
 RUN apk update && apk upgrade && \
@@ -53,11 +59,9 @@ COPY --from=builder /app/packages/shared/dist ./packages/shared/dist
 COPY --from=builder /app/packages/shared/package.json ./packages/shared/
 COPY --from=builder /app/package.json ./
 
-# Include the migration runner and SQL migrations so an init container can run
-# `bun run src/db/migrate.ts` against the database before the app starts.
-# migrate.ts only depends on drizzle-orm + pg (already in node_modules), so it
-# runs standalone without the rest of the source tree.
-COPY --from=builder /app/packages/backend/src/db/migrate.ts ./packages/backend/src/db/migrate.ts
+# Include the SQL migrations so an init container can run the bundled migration
+# runner (dist/migrate.js, already included with dist above) against the
+# database before the app starts. The migrator reads these SQL files at runtime.
 COPY --from=builder /app/packages/backend/drizzle ./packages/backend/drizzle
 
 # Create uploads directory with proper permissions

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -53,6 +53,13 @@ COPY --from=builder /app/packages/shared/dist ./packages/shared/dist
 COPY --from=builder /app/packages/shared/package.json ./packages/shared/
 COPY --from=builder /app/package.json ./
 
+# Include the migration runner and SQL migrations so an init container can run
+# `bun run src/db/migrate.ts` against the database before the app starts.
+# migrate.ts only depends on drizzle-orm + pg (already in node_modules), so it
+# runs standalone without the rest of the source tree.
+COPY --from=builder /app/packages/backend/src/db/migrate.ts ./packages/backend/src/db/migrate.ts
+COPY --from=builder /app/packages/backend/drizzle ./packages/backend/drizzle
+
 # Create uploads directory with proper permissions
 RUN mkdir -p /app/uploads && chown -R rox:rox /app
 

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -4,7 +4,7 @@
 # ============================================
 # Stage 1: Build
 # ============================================
-FROM oven/bun:1.3-alpine AS builder
+FROM oven/bun:1.3 AS builder
 
 WORKDIR /app
 
@@ -23,11 +23,14 @@ COPY packages/backend ./packages/backend
 COPY packages/shared ./packages/shared
 COPY tsconfig.json ./
 
-# Build shared package
-WORKDIR /app/packages/shared
-RUN bun run build
+# Set production AFTER install (so devDeps are available for the build) and
+# BEFORE bundling: `bun build` inlines process.env.NODE_ENV at build time, so it
+# must be "production" here for the bundle to behave as production at runtime.
+ENV NODE_ENV=production
 
-# Build backend (app entrypoint)
+# Build backend (app entrypoint). The shared package is consumed from source
+# (its package.json `main` points at src/index.ts) and bun bundles it into the
+# output, so there is no separate shared build/dist step.
 WORKDIR /app/packages/backend
 RUN bun run build
 
@@ -38,16 +41,17 @@ RUN bun build src/db/migrate.ts --outdir dist --target bun
 # ============================================
 # Stage 2: Production
 # ============================================
-FROM oven/bun:1.3-alpine AS production
+FROM oven/bun:1.3 AS production
 
-# Install security updates and required packages
-RUN apk update && apk upgrade && \
-    apk add --no-cache curl && \
-    rm -rf /var/cache/apk/*
+# Install security updates and required packages (Debian/glibc base so the
+# prebuilt sharp binaries load reliably).
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends curl && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create non-root user for security
-RUN addgroup -g 1001 -S rox && \
-    adduser -S -D -H -u 1001 -s /sbin/nologin -G rox rox
+RUN groupadd -g 1001 rox && \
+    useradd -r -u 1001 -g rox -s /usr/sbin/nologin rox
 
 WORKDIR /app
 
@@ -55,7 +59,6 @@ WORKDIR /app
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/packages/backend/dist ./packages/backend/dist
 COPY --from=builder /app/packages/backend/package.json ./packages/backend/
-COPY --from=builder /app/packages/shared/dist ./packages/shared/dist
 COPY --from=builder /app/packages/shared/package.json ./packages/shared/
 COPY --from=builder /app/package.json ./
 

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -10,7 +10,7 @@ WORKDIR /app
 
 # Copy package files. All workspace package.json files are required so
 # `bun install --frozen-lockfile` can validate the workspace lockfile.
-COPY package.json bun.lock ./
+COPY package.json bun.lock bunfig.toml ./
 COPY packages/backend/package.json ./packages/backend/
 COPY packages/shared/package.json ./packages/shared/
 COPY packages/frontend/package.json ./packages/frontend/
@@ -55,7 +55,10 @@ RUN groupadd -g 1001 rox && \
 
 WORKDIR /app
 
-# Copy built files and dependencies
+# Copy built files and dependencies. With the hoisted node_modules linker
+# (bunfig.toml), this single flat node_modules contains every dependency —
+# including native ones like sharp's `@img/sharp-linux-x64`, which the bundle
+# resolves at runtime.
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/packages/backend/dist ./packages/backend/dist
 COPY --from=builder /app/packages/backend/package.json ./packages/backend/

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -4,7 +4,7 @@
 # ============================================
 # Stage 1: Build
 # ============================================
-FROM oven/bun:1.3-alpine AS builder
+FROM oven/bun:1.3 AS builder
 
 WORKDIR /app
 
@@ -23,26 +23,28 @@ COPY packages/frontend ./packages/frontend
 COPY packages/shared ./packages/shared
 COPY tsconfig.json ./
 
-# Build shared package
-WORKDIR /app/packages/shared
-RUN bun run build
+# Set production AFTER install (so devDeps are available for the build) and
+# BEFORE building, so any build-time NODE_ENV inlining reflects production.
+ENV NODE_ENV=production
 
-# Build frontend (Waku)
+# Build frontend (Waku). The shared package is consumed from source (its
+# package.json `main` points at src/index.ts) and the bundler inlines it, so
+# there is no separate shared build/dist step.
 WORKDIR /app/packages/frontend
 RUN bun run build
 
 # ============================================
 # Stage 2: Production
 # ============================================
-FROM oven/bun:1.3-alpine AS production
+FROM oven/bun:1.3 AS production
 
-# Install security updates
-RUN apk update && apk upgrade && \
-    rm -rf /var/cache/apk/*
+# Install security updates (Debian/glibc base, consistent with the backend)
+RUN apt-get update && apt-get upgrade -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create non-root user for security
-RUN addgroup -g 1001 -S rox && \
-    adduser -S -D -H -u 1001 -s /sbin/nologin -G rox rox
+RUN groupadd -g 1001 rox && \
+    useradd -r -u 1001 -g rox -s /usr/sbin/nologin rox
 
 WORKDIR /app
 
@@ -51,7 +53,6 @@ COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/packages/frontend/dist ./packages/frontend/dist
 COPY --from=builder /app/packages/frontend/package.json ./packages/frontend/
 COPY --from=builder /app/packages/frontend/start.ts ./packages/frontend/
-COPY --from=builder /app/packages/shared/dist ./packages/shared/dist
 COPY --from=builder /app/packages/shared/package.json ./packages/shared/
 COPY --from=builder /app/package.json ./
 

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -10,7 +10,7 @@ WORKDIR /app
 
 # Copy package files. All workspace package.json files are required so
 # `bun install --frozen-lockfile` can validate the workspace lockfile.
-COPY package.json bun.lock ./
+COPY package.json bun.lock bunfig.toml ./
 COPY packages/frontend/package.json ./packages/frontend/
 COPY packages/shared/package.json ./packages/shared/
 COPY packages/backend/package.json ./packages/backend/

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -4,14 +4,16 @@
 # ============================================
 # Stage 1: Build
 # ============================================
-FROM oven/bun:1.1-alpine AS builder
+FROM oven/bun:1.3-alpine AS builder
 
 WORKDIR /app
 
-# Copy package files
+# Copy package files. All workspace package.json files are required so
+# `bun install --frozen-lockfile` can validate the workspace lockfile.
 COPY package.json bun.lock ./
 COPY packages/frontend/package.json ./packages/frontend/
 COPY packages/shared/package.json ./packages/shared/
+COPY packages/backend/package.json ./packages/backend/
 
 # Install dependencies
 RUN bun install --frozen-lockfile
@@ -32,7 +34,7 @@ RUN bun run build
 # ============================================
 # Stage 2: Production
 # ============================================
-FROM oven/bun:1.1-alpine AS production
+FROM oven/bun:1.3-alpine AS production
 
 # Install security updates
 RUN apk update && apk upgrade && \

--- a/docs/release-notes/v2026.7.0-rc.2.md
+++ b/docs/release-notes/v2026.7.0-rc.2.md
@@ -1,0 +1,19 @@
+> **Release candidate (`-rc.2`).** Iterates on `v2026.7.0-rc.1`. No new database migrations since rc.1.
+
+```bash
+git pull origin main
+bun install --frozen-lockfile
+bun run build
+```
+
+### Mobile deck: smoother horizontal swipe
+
+- The mobile deck now uses a **native CSS scroll-snap carousel** (one column per screen) instead of the previous custom touch handling. Swiping follows your finger with real momentum, the adjacent column slides in as you swipe, vertical scrolling inside a column no longer fights the horizontal swipe, and pages snap cleanly. Horizontal overscroll no longer triggers the browser's back/forward navigation.
+
+### Container images & Kubernetes deployment (for self-hosters)
+
+- Backend and frontend **container images are now published to GHCR** (`ghcr.io/love-rox/rox-backend`, `ghcr.io/love-rox/rox-frontend`) by a CI workflow on `dev`/`main`/`v*`.
+- A ready-to-use **K3S/Kubernetes manifest set** is included under `deploy/k8s/rox/` (namespace, in-cluster TimescaleDB, Dragonfly, nginx, backend with a migration init container), designed for GHCR + keel-style auto-update.
+- Image hardening found along the way: Debian/glibc base images (reliable `sharp`), `NODE_ENV=production` baked at build time (structured JSON logs in production; the `pino-pretty` transport is now development-only), and a hoisted bun `node_modules` layout so bundled native dependencies resolve.
+
+These deployment additions are optional and do not change the traditional install.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rox",
-  "version": "2026.7.0-rc.1",
+  "version": "2026.7.0-rc.2",
   "license": "AGPL-3.0-only",
   "devDependencies": {
     "@playwright/test": "^1.61.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hono_rox",
-  "version": "1.9.0-rc.1",
+  "version": "1.9.0-rc.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/backend/src/lib/logger.ts
+++ b/packages/backend/src/lib/logger.ts
@@ -70,7 +70,10 @@ function createLoggerConfig(config: LoggerConfig = {}): pino.LoggerOptions {
  */
 function createTransport(config: LoggerConfig = {}): pino.TransportSingleOptions | undefined {
   const isProduction = process.env.NODE_ENV === "production";
-  const pretty = config.pretty ?? true;
+  // Pretty printing (via the pino-pretty transport) is for development only.
+  // In production we emit structured JSON, which also avoids requiring the
+  // pino-pretty module at runtime (it isn't bundled into the production image).
+  const pretty = config.pretty ?? !isProduction;
 
   if (pretty) {
     return {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waku_rox",
-  "version": "1.9.0-rc.1",
+  "version": "1.9.0-rc.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/frontend/src/components/deck/DeckLayout.tsx
+++ b/packages/frontend/src/components/deck/DeckLayout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import React, { useCallback, useRef, useState, useEffect } from "react";
-import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { useCallback, useRef, useEffect } from "react";
+import { useAtom, useAtomValue } from "jotai";
 import {
   DndContext,
   closestCenter,
@@ -17,7 +17,7 @@ import {
   horizontalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { Trans } from "@lingui/react/macro";
-import { mobileActiveColumnIndexAtom, setMobileActiveColumnAtom } from "../../lib/atoms/deck";
+import { mobileActiveColumnIndexAtom } from "../../lib/atoms/deck";
 import { currentUserAtom } from "../../lib/atoms/auth";
 import { useDeckProfiles } from "../../hooks/useDeckProfiles";
 import { sidebarCollapsedAtom } from "../../lib/atoms/sidebar";
@@ -66,7 +66,6 @@ export function DeckLayout({ showAddColumn = true, showProfileSwitcher = true }:
   const { activeProfile, updateActiveColumns } = useDeckProfiles();
   const columns = activeProfile?.columns ?? [];
   const [mobileColumnIndex, setMobileColumnIndex] = useAtom(mobileActiveColumnIndexAtom);
-  const setMobileColumn = useSetAtom(setMobileActiveColumnAtom);
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
@@ -107,27 +106,34 @@ export function DeckLayout({ showAddColumn = true, showProfileSwitcher = true }:
     [columns, updateActiveColumns],
   );
 
-  // Handle mobile swipe
-  const handleMobileSwipe = useCallback(
-    (direction: "left" | "right") => {
-      if (direction === "left" && mobileColumnIndex < columns.length - 1) {
-        setMobileColumn(mobileColumnIndex + 1);
-      } else if (direction === "right" && mobileColumnIndex > 0) {
-        setMobileColumn(mobileColumnIndex - 1);
+  // Mobile carousel: a native CSS scroll-snap track. The browser handles the
+  // finger-following swipe, momentum, axis locking (vertical scroll inside a
+  // column vs horizontal swipe between columns) and snapping — far smoother
+  // than the previous custom touch handlers.
+  const mobileScrollRef = useRef<HTMLDivElement>(null);
+  const mobileScrollRaf = useRef<number | null>(null);
+
+  // Derive the active column index from the carousel scroll position.
+  // rAF-throttled so rapid scroll events don't thrash React state.
+  const handleMobileScroll = useCallback(() => {
+    if (mobileScrollRaf.current != null) return;
+    mobileScrollRaf.current = requestAnimationFrame(() => {
+      mobileScrollRaf.current = null;
+      const el = mobileScrollRef.current;
+      if (!el || el.clientWidth === 0) return;
+      const index = Math.round(el.scrollLeft / el.clientWidth);
+      if (index >= 0 && index < columns.length && index !== mobileColumnIndex) {
+        setMobileColumnIndex(index);
       }
-    },
-    [mobileColumnIndex, columns.length, setMobileColumn],
-  );
+    });
+  }, [columns.length, mobileColumnIndex, setMobileColumnIndex]);
 
-  // Mobile touch handling with visual feedback
-  const touchStartRef = useRef<{ x: number; y: number } | null>(null);
-  const [swipeOffset, setSwipeOffset] = useState(0);
-  const [isTransitioning, setIsTransitioning] = useState(false);
-
-  // Reset swipe offset when column index changes
-  useEffect(() => {
-    setSwipeOffset(0);
-  }, [mobileColumnIndex]);
+  // Smoothly scroll the carousel to a column (used by the indicator dots).
+  const scrollToColumn = useCallback((index: number) => {
+    const el = mobileScrollRef.current;
+    if (!el) return;
+    el.scrollTo({ left: index * el.clientWidth, behavior: "smooth" });
+  }, []);
 
   // Ensure mobile index stays within bounds when columns change
   useEffect(() => {
@@ -136,74 +142,17 @@ export function DeckLayout({ showAddColumn = true, showProfileSwitcher = true }:
     }
   }, [columns.length, mobileColumnIndex, setMobileColumnIndex]);
 
-  // Reset scroll position to start when profile changes or on initial load
+  // Reset scroll position to start when the profile changes or on initial load.
+  // Instant (no smooth) so the carousel does not visibly slide on appear.
   useEffect(() => {
     if (scrollContainerRef.current) {
       scrollContainerRef.current.scrollLeft = 0;
     }
-    // Also reset mobile column index to first column
+    if (mobileScrollRef.current) {
+      mobileScrollRef.current.scrollLeft = 0;
+    }
     setMobileColumnIndex(0);
   }, [activeProfile?.id, setMobileColumnIndex]);
-
-  const handleTouchStart = useCallback((e: React.TouchEvent) => {
-    const touch = e.touches[0];
-    if (touch) {
-      touchStartRef.current = { x: touch.clientX, y: touch.clientY };
-      setIsTransitioning(false);
-    }
-  }, []);
-
-  const handleTouchMove = useCallback(
-    (e: React.TouchEvent) => {
-      if (!touchStartRef.current) return;
-
-      const touch = e.touches[0];
-      if (!touch) return;
-
-      const deltaX = touch.clientX - touchStartRef.current.x;
-      const deltaY = touch.clientY - touchStartRef.current.y;
-
-      // Only handle horizontal swipes (with some tolerance)
-      if (Math.abs(deltaX) > Math.abs(deltaY)) {
-        // Limit swipe offset at edges
-        const canSwipeLeft = mobileColumnIndex < columns.length - 1;
-        const canSwipeRight = mobileColumnIndex > 0;
-
-        let offset = deltaX;
-        if (deltaX < 0 && !canSwipeLeft) {
-          offset = deltaX * 0.2; // Resistance at edge
-        } else if (deltaX > 0 && !canSwipeRight) {
-          offset = deltaX * 0.2; // Resistance at edge
-        }
-
-        setSwipeOffset(offset);
-      }
-    },
-    [mobileColumnIndex, columns.length],
-  );
-
-  const handleTouchEnd = useCallback(
-    (e: React.TouchEvent) => {
-      if (!touchStartRef.current) return;
-
-      const touch = e.changedTouches[0];
-      if (!touch) return;
-
-      const deltaX = touch.clientX - touchStartRef.current.x;
-      const deltaY = touch.clientY - touchStartRef.current.y;
-
-      // Only handle horizontal swipes
-      if (Math.abs(deltaX) > Math.abs(deltaY) && Math.abs(deltaX) > 50) {
-        setIsTransitioning(true);
-        handleMobileSwipe(deltaX > 0 ? "right" : "left");
-      }
-
-      // Reset offset with animation
-      setSwipeOffset(0);
-      touchStartRef.current = null;
-    },
-    [handleMobileSwipe],
-  );
 
   // Sidebar margin for desktop
   const sidebarMarginClass = currentUser ? (isCollapsed ? "lg:ml-16" : "lg:ml-64") : "";
@@ -279,24 +228,29 @@ export function DeckLayout({ showAddColumn = true, showProfileSwitcher = true }:
           </DndContext>
         </div>
 
-        {/* Mobile: Single column with swipe */}
-        {/* Uses flex-1 to fill remaining space, accounting for mobile app bar */}
+        {/* Mobile: native scroll-snap carousel (one column per screen).
+            The browser handles finger-following swipe, momentum and snapping;
+            overscroll-x-contain prevents the horizontal swipe from triggering
+            the browser's back/forward navigation. */}
         <div
-          className="lg:hidden flex-1 min-h-0 overflow-hidden"
+          className="lg:hidden flex-1 min-h-0"
           style={{
             // Subtract the mobile app bar height (3.5rem + safe-area)
             marginBottom: "calc(3.5rem + env(safe-area-inset-bottom, 0px))",
           }}
-          onTouchStart={handleTouchStart}
-          onTouchMove={handleTouchMove}
-          onTouchEnd={handleTouchEnd}
         >
-          {columns.length > 0 && columns[mobileColumnIndex] ? (
+          {columns.length > 0 ? (
             <div
-              className={`h-full ${isTransitioning ? "transition-transform duration-200 ease-out" : ""}`}
-              style={{ transform: `translateX(${swipeOffset}px)` }}
+              ref={mobileScrollRef}
+              onScroll={handleMobileScroll}
+              className="flex h-full overflow-x-auto overflow-y-hidden snap-x snap-mandatory overscroll-x-contain"
+              style={{ scrollbarWidth: "none" }}
             >
-              <DeckColumn column={columns[mobileColumnIndex]} isMobile />
+              {columns.map((column) => (
+                <div key={column.id} className="w-full shrink-0 snap-start h-full">
+                  <DeckColumn column={column} isMobile />
+                </div>
+              ))}
             </div>
           ) : (
             /* Empty state when no columns */
@@ -319,7 +273,7 @@ export function DeckLayout({ showAddColumn = true, showProfileSwitcher = true }:
               {columns.map((col, index) => (
                 <button
                   key={col.id}
-                  onClick={() => setMobileColumnIndex(index)}
+                  onClick={() => scrollToColumn(index)}
                   className={`w-2.5 h-2.5 rounded-full transition-all duration-200 ${
                     index === mobileColumnIndex
                       ? "bg-(--accent-color) scale-110"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shared",
-  "version": "1.9.0-rc.1",
+  "version": "1.9.0-rc.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
## Release v2026.7.0-rc.2

auto-tag が `v2026.7.0-rc.2` を **prerelease** として作成し、`docs/release-notes/v2026.7.0-rc.2.md` を Upgrade Notes に取り込みます。

### 主な内容
- **モバイルデッキの横スワイプ改善**: ネイティブ scroll-snap カルーセル化(指追従・慣性・軸ロック・スナップ、戻るジェスチャ誤爆防止)。
- セルフホスト向け: GHCR イメージ公開 + K3S マニフェスト一式(`deploy/k8s/rox/`)、Debian ベース/本番JSONログ/hoisted linker など。

### 注意
- rc.1 以降の **新規 DB マイグレーションなし**。
- バージョン: root `2026.7.0-rc.2` / packages `1.9.0-rc.2`(RC: 本番投入前にステージング検証推奨)。

https://claude.ai/code/session_01F47UqfYk5iRxDuokkyyzLr