### PR TITLE
fix(k8s): backend metrics via internal NodePort (Prometheus)

### DIFF
--- a/deploy/k8s/rox/30-backend.yaml
+++ b/deploy/k8s/rox/30-backend.yaml
@@ -6,12 +6,18 @@ metadata:
   labels:
     app: rox-backend
 spec:
+  # NodePort so an out-of-cluster Prometheus (on the monitoring host, reachable
+  # over the node/Tailscale network) can scrape the backend's /metrics directly
+  # — mirroring the old bare-metal setup (backend on an internal port), without
+  # exposing /metrics through the public Cloudflare tunnel.
+  type: NodePort
   selector:
     app: rox-backend
   ports:
     - name: http
       port: 3000
       targetPort: 3000
+      nodePort: 30092
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/k8s/rox/50-nginx.yaml
+++ b/deploy/k8s/rox/50-nginx.yaml
@@ -235,6 +235,11 @@ data:
             proxy_buffering off;
         }
 
+        # NOTE: /metrics is intentionally NOT proxied here — it would become
+        # publicly reachable via the Cloudflare tunnel. Prometheus scrapes the
+        # backend's metrics over the internal node/Tailscale network via the
+        # rox-backend NodePort (30092) instead.
+
         location /uploads/ {
             alias /app/uploads/;
             expires 30d;


### PR DESCRIPTION
K3S移行後、外部 Prometheus が停止済みベアメタル backend(100.96.0.11:43000)を scrape し続け InstanceDown が発火していた。backend を内部 NodePort 30092 で公開し Prometheus をそこに向けた(公開トンネルには /metrics を出さない)。Prometheus 側 target 変更+リロードは監視ホストで実施済み(本リポジトリ外)。up=1・アラート解消を確認。

https://claude.ai/code/session_01F47UqfYk5iRxDuokkyyzLr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * `/metrics` を外部監視から直接取得しやすくなりました。
  * 監視向けの到達経路が明確になり、バックエンドへ直接スクレイプできるようになりました。
* **Documentation**
  * `Nginx` 側で `/metrics` を中継しないことを明示し、監視の接続先がわかりやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->