### PR TITLE
perf(deck): smoother mobile swipe (settle-debounced index + memo)

### DIFF
--- a/packages/frontend/src/components/deck/DeckColumn.tsx
+++ b/packages/frontend/src/components/deck/DeckColumn.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState, useMemo } from "react";
+import { memo, useCallback, useState, useMemo } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import {
@@ -110,7 +110,7 @@ interface WidthOption {
  *
  * Supports drag-and-drop reordering, width adjustment, and removal.
  */
-export function DeckColumn({ column, isMobile = false }: DeckColumnProps) {
+function DeckColumnImpl({ column, isMobile = false }: DeckColumnProps) {
   const { t } = useLingui();
   const { activeProfile, updateActiveColumns } = useDeckProfiles();
   const columns = activeProfile?.columns ?? [];
@@ -311,3 +311,10 @@ export function DeckColumn({ column, isMobile = false }: DeckColumnProps) {
     </div>
   );
 }
+
+/**
+ * Memoized so the deck re-rendering (e.g. when the mobile active-column index
+ * settles) doesn't reconcile every column's subtree — only columns whose props
+ * actually change re-render.
+ */
+export const DeckColumn = memo(DeckColumnImpl);

--- a/packages/frontend/src/components/deck/DeckLayout.tsx
+++ b/packages/frontend/src/components/deck/DeckLayout.tsx
@@ -111,22 +111,31 @@ export function DeckLayout({ showAddColumn = true, showProfileSwitcher = true }:
   // column vs horizontal swipe between columns) and snapping — far smoother
   // than the previous custom touch handlers.
   const mobileScrollRef = useRef<HTMLDivElement>(null);
-  const mobileScrollRaf = useRef<number | null>(null);
+  const mobileScrollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Derive the active column index from the carousel scroll position.
-  // rAF-throttled so rapid scroll events don't thrash React state.
+  // Update the active column index only AFTER the swipe settles. Updating React
+  // state mid-scroll re-renders the deck during the gesture and makes the snap
+  // stutter; debouncing to scroll-end keeps the swipe itself purely native and
+  // CSS-smooth, and the (cheap) index update lands once the motion has stopped.
   const handleMobileScroll = useCallback(() => {
-    if (mobileScrollRaf.current != null) return;
-    mobileScrollRaf.current = requestAnimationFrame(() => {
-      mobileScrollRaf.current = null;
+    if (mobileScrollTimer.current != null) clearTimeout(mobileScrollTimer.current);
+    mobileScrollTimer.current = setTimeout(() => {
+      mobileScrollTimer.current = null;
       const el = mobileScrollRef.current;
       if (!el || el.clientWidth === 0) return;
       const index = Math.round(el.scrollLeft / el.clientWidth);
       if (index >= 0 && index < columns.length && index !== mobileColumnIndex) {
         setMobileColumnIndex(index);
       }
-    });
+    }, 140);
   }, [columns.length, mobileColumnIndex, setMobileColumnIndex]);
+
+  // Clear any pending scroll-settle timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (mobileScrollTimer.current != null) clearTimeout(mobileScrollTimer.current);
+    };
+  }, []);
 
   // Smoothly scroll the carousel to a column (used by the indicator dots).
   const scrollToColumn = useCallback((index: number) => {
@@ -244,10 +253,10 @@ export function DeckLayout({ showAddColumn = true, showProfileSwitcher = true }:
               ref={mobileScrollRef}
               onScroll={handleMobileScroll}
               className="flex h-full overflow-x-auto overflow-y-hidden snap-x snap-mandatory overscroll-x-contain"
-              style={{ scrollbarWidth: "none" }}
+              style={{ scrollbarWidth: "none", WebkitOverflowScrolling: "touch" }}
             >
               {columns.map((column) => (
-                <div key={column.id} className="w-full shrink-0 snap-start h-full">
+                <div key={column.id} className="w-full shrink-0 snap-start snap-always h-full">
                   <DeckColumn column={column} isMobile />
                 </div>
               ))}


### PR DESCRIPTION
モバイルのスワイプがあと一歩スムーズでない件の調整。

- スワイプ中に onScroll が active-column atom を更新→デッキ全体+全DeckColumn(未メモ化)が再レンダーしスナップがカクついていた。
- インデックス更新をスクロール確定後(~140ms)に遅延し、ジェスチャ中の再レンダーをゼロに。
- DeckColumn を React.memo 化。
- scroll-snap-stop: always(1フリック=1カラム)+ iOS 慣性(-webkit-overflow-scrolling: touch)。

frontend typecheck / lint パス。マージで keel により本番へ自動反映。

https://claude.ai/code/session_01F47UqfYk5iRxDuokkyyzLr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * モバイルのデッキ表示で、横スクロール時のスナップ挙動がより安定しました。
* **パフォーマンス改善**
  * デッキ列の再描画を抑え、画面更新時の動作を軽くしました。
* **バグ修正**
  * モバイルでのアクティブ列の切り替えが、スクロール終了後により正確に反映されるようになりました。
  * iPhone などでの慣性スクロール体験を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->