### PR TITLE
fix(k8s): deterministic autodeploy CronJob (replaces keel)

### DIFF
--- a/deploy/k8s/rox/30-backend.yaml
+++ b/deploy/k8s/rox/30-backend.yaml
@@ -24,11 +24,9 @@ kind: Deployment
 metadata:
   name: rox-backend
   namespace: rox
-  annotations:
-    # keel auto-updates this deployment when the :dev tag's digest changes.
-    keel.sh/policy: force
-    keel.sh/trigger: poll
-    keel.sh/pollSchedule: "@every 3m"
+  # Auto-update is handled by the rox-autodeploy CronJob (60-autodeploy.yaml),
+  # not keel: keel mis-resolved the :dev tag among sibling tags and its
+  # ServiceAccount lacks RBAC in this namespace.
 spec:
   replicas: 1
   revisionHistoryLimit: 3

--- a/deploy/k8s/rox/40-frontend.yaml
+++ b/deploy/k8s/rox/40-frontend.yaml
@@ -18,10 +18,7 @@ kind: Deployment
 metadata:
   name: rox-frontend
   namespace: rox
-  annotations:
-    keel.sh/policy: force
-    keel.sh/trigger: poll
-    keel.sh/pollSchedule: "@every 3m"
+  # Auto-update is handled by the rox-autodeploy CronJob (60-autodeploy.yaml).
 spec:
   replicas: 1
   revisionHistoryLimit: 3

--- a/deploy/k8s/rox/60-autodeploy.yaml
+++ b/deploy/k8s/rox/60-autodeploy.yaml
@@ -1,0 +1,104 @@
+# Deterministic auto-deploy for the Rox deployments (replaces keel).
+#
+# Every 5 minutes, fetch the digest of the `:dev` tag for each image directly
+# from GHCR (anonymous pull token) and, if it differs from the running pod,
+# `kubectl set image ...@<digest>`. This pins to the exact `:dev` tag (no tag
+# resolution ambiguity) and uses a ServiceAccount scoped to the `rox` namespace
+# (keel's SA lacked RBAC here and mis-resolved the tag).
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rox-autodeploy
+  namespace: rox
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rox-autodeploy
+  namespace: rox
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rox-autodeploy
+  namespace: rox
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rox-autodeploy
+subjects:
+  - kind: ServiceAccount
+    name: rox-autodeploy
+    namespace: rox
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: rox-autodeploy
+  namespace: rox
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 120
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 120
+      template:
+        spec:
+          serviceAccountName: rox-autodeploy
+          restartPolicy: Never
+          # Pin to a node that can reach GHCR and the API server.
+          nodeSelector:
+            kubernetes.io/hostname: sakura
+          containers:
+            - name: autodeploy
+              image: alpine/k8s:1.31.1
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests: { cpu: 10m, memory: 32Mi }
+                limits: { cpu: 200m, memory: 128Mi }
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  TAG=dev
+                  # deployment:container:repo (container name == deployment name here)
+                  for ENTRY in \
+                    "rox-backend:rox-backend:love-rox/rox-backend" \
+                    "rox-frontend:rox-frontend:love-rox/rox-frontend"; do
+                    DEP="${ENTRY%%:*}"; REST="${ENTRY#*:}"
+                    CONTAINER="${REST%%:*}"; REPO="${REST#*:}"
+                    IMG="ghcr.io/${REPO}"
+                    echo "[autodeploy] checking ${IMG}:${TAG}"
+                    TOKEN=$(curl -fsSL "https://ghcr.io/token?scope=repository:${REPO}:pull" | jq -r .token)
+                    LATEST=$(curl -fsSL -o /dev/null -D - \
+                      -H "Authorization: Bearer ${TOKEN}" \
+                      -H "Accept: application/vnd.docker.distribution.manifest.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.oci.image.index.v1+json" \
+                      "https://ghcr.io/v2/${REPO}/manifests/${TAG}" \
+                      | grep -i '^docker-content-digest:' | awk '{print $2}' | tr -d '\r')
+                    case "$LATEST" in
+                      sha256:*) : ;;
+                      *) echo "[autodeploy] digest fetch failed for ${REPO}: '${LATEST}'"; continue ;;
+                    esac
+                    RUNNING=$(kubectl -n rox get pods -l app="${DEP}" \
+                      -o jsonpath='{range .items[*]}{.status.containerStatuses[0].imageID}{"\n"}{end}' \
+                      | grep -oE 'sha256:[a-f0-9]+' | head -1 || true)
+                    echo "[autodeploy] ${DEP}: latest=${LATEST} running=${RUNNING}"
+                    if [ "$RUNNING" = "$LATEST" ]; then
+                      echo "[autodeploy] ${DEP} up to date"
+                    else
+                      echo "[autodeploy] updating ${DEP} -> ${IMG}@${LATEST}"
+                      kubectl -n rox set image "deployment/${DEP}" "${CONTAINER}=${IMG}@${LATEST}"
+                    fi
+                  done

--- a/deploy/k8s/rox/README.md
+++ b/deploy/k8s/rox/README.md
@@ -2,8 +2,8 @@
 
 Manifests for running Rox on the existing K3S cluster (control-plane
 `samurai-watch`, worker `sakura` which holds the public IP and storage),
-mirroring the ikaskey operational pattern: images on GHCR, auto-updated by
-**keel** tracking the `:dev` tag.
+mirroring the ikaskey operational pattern: images on GHCR, auto-updated by a
+**digest-diff CronJob** tracking the `:dev` tag.
 
 ## Components (namespace `rox`, all pinned to node `sakura`)
 
@@ -14,13 +14,18 @@ mirroring the ikaskey operational pattern: images on GHCR, auto-updated by
 | `10-timescaledb.yaml` | TimescaleDB (PG16) StatefulSet + headless Service (charts backend) |
 | `20-dragonfly.yaml` | Dragonfly (Redis-compatible) for cache/queue |
 | `25-uploads-pvc.yaml` | shared local-path PVC for uploads (backend rw, nginx ro) |
-| `30-backend.yaml` | `hono_rox` Deployment (initContainer runs migrations) + Service; keel-managed |
-| `40-frontend.yaml` | `waku_rox` Deployment + Service; keel-managed |
+| `30-backend.yaml` | `hono_rox` Deployment (initContainer runs migrations) + NodePort Service (`30092`, metrics) |
+| `40-frontend.yaml` | `waku_rox` Deployment + Service |
 | `50-nginx.yaml` | nginx reverse proxy (path + Accept-header routing) + NodePort `30091` |
+| `60-autodeploy.yaml` | CronJob (+ SA/Role) that auto-updates the deployments from `:dev` |
 
-Auto-update: the existing cluster-wide keel (ns `ikaskey-gatekeeper`) polls the
-`:dev` images every 3 min and rolls the backend/frontend Deployments on digest
-change. The backend initContainer applies DB migrations on each boot.
+Auto-update: the `rox-autodeploy` CronJob (`60-autodeploy.yaml`) runs every 5
+minutes, fetches the digest of each image's `:dev` tag from GHCR, and runs
+`kubectl set image ...@<digest>` when it differs from the running pod. This is
+deterministic (pinned to the exact `:dev` tag) and uses a ServiceAccount scoped
+to the `rox` namespace. (keel was tried first but mis-resolved the `:dev` tag
+among sibling tags and its SA lacked RBAC here.) The backend initContainer
+applies DB migrations on each boot.
 
 ## Images
 


### PR DESCRIPTION
keel が rox を自動更新できていなかった(SA の RBAC 不足 + :dev のタグ誤解決で dev->fix-image-runtime を試行)。ikaskey と同様の digest-diff CronJob 方式に置換。

- backend/frontend から keel アノテーション除去
- rox-autodeploy CronJob(+SA/Role、ns rox 限定)を追加: 5分毎に :dev の digest を GHCR から取得し、稼働 Pod と異なれば kubectl set image
- クラスタ実機で動作確認済み(両 deployment up to date / patch 権限OK)

https://claude.ai/code/session_01F47UqfYk5iRxDuokkyyzLr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `rox-backend` と `rox-frontend` のイメージ更新方法が見直され、`dev` タグの変更を定期的に反映する自動更新に切り替わりました。
  * 変更時のみイメージを更新する仕組みになり、更新内容がより安定しました。

* **ドキュメント**
  * 自動更新の方式と構成説明を最新の運用に合わせて更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->