### PR TITLE
feat: build number + dev channel indicator

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -74,3 +74,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           provenance: false
+          build-args: |
+            ROX_BUILD_SHA=${{ github.sha }}
+            ROX_BUILD_CHANNEL=${{ github.ref_name }}

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -28,6 +28,14 @@ COPY tsconfig.json ./
 # must be "production" here for the bundle to behave as production at runtime.
 ENV NODE_ENV=production
 
+# Build identity (short git SHA + source ref), injected by CI. Set before the
+# bundle in case bun inlines the values, and again in the production stage for
+# runtime reads.
+ARG ROX_BUILD_SHA=local
+ARG ROX_BUILD_CHANNEL=local
+ENV ROX_BUILD_SHA=${ROX_BUILD_SHA} \
+    ROX_BUILD_CHANNEL=${ROX_BUILD_CHANNEL}
+
 # Build backend (app entrypoint). The shared package is consumed from source
 # (its package.json `main` points at src/index.ts) and bun bundles it into the
 # output, so there is no separate shared build/dist step.
@@ -84,9 +92,13 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:3000/health || exit 1
 
 # Set environment defaults
+ARG ROX_BUILD_SHA=local
+ARG ROX_BUILD_CHANNEL=local
 ENV NODE_ENV=production \
     PORT=3000 \
-    DB_TYPE=postgres
+    DB_TYPE=postgres \
+    ROX_BUILD_SHA=${ROX_BUILD_SHA} \
+    ROX_BUILD_CHANNEL=${ROX_BUILD_CHANNEL}
 
 # Run the application
 CMD ["bun", "run", "packages/backend/dist/index.js"]

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -65,7 +65,10 @@ USER rox
 # Expose port
 EXPOSE 3001
 
-# Set environment defaults
+# Set environment defaults. ROX_BUILD_* are accepted (and ignored) here so the
+# shared CI build-args don't warn; the build identity is served by the backend.
+ARG ROX_BUILD_SHA=local
+ARG ROX_BUILD_CHANNEL=local
 ENV NODE_ENV=production \
     FRONTEND_PORT=3001
 

--- a/packages/backend/src/routes/instance.ts
+++ b/packages/backend/src/routes/instance.ts
@@ -16,6 +16,12 @@ import rootPackageJson from "../../../../package.json";
 // Get version from root package.json
 const ROX_VERSION = rootPackageJson.version;
 
+// Build identity, injected at image build time (see docker/Dockerfile.backend).
+// `build` is the short git SHA; `channel` is the source ref (e.g. "dev",
+// "main", a tag). Both fall back to "local" for non-CI builds.
+const ROX_BUILD = (process.env.ROX_BUILD_SHA || "").slice(0, 7) || "local";
+const ROX_CHANNEL = process.env.ROX_BUILD_CHANNEL || "local";
+
 const app = new Hono();
 
 /**
@@ -71,6 +77,8 @@ app.get("/", async (c: Context) => {
     software: {
       name: "rox",
       version: ROX_VERSION,
+      build: ROX_BUILD,
+      channel: ROX_CHANNEL,
       repository: "https://github.com/Love-rox/rox",
     },
   });

--- a/packages/frontend/src/components/layout/Sidebar.tsx
+++ b/packages/frontend/src/components/layout/Sidebar.tsx
@@ -292,10 +292,18 @@ export function Sidebar() {
           <SpaLink
             to="/settings?tab=advanced"
             onClick={handleNavClick}
-            className="text-xs text-(--text-muted) hover:text-(--text-secondary) transition-colors"
-            title={`${instanceInfo.software.name} v${instanceInfo.software.version}`}
+            className="flex items-center gap-1 text-xs text-(--text-muted) hover:text-(--text-secondary) transition-colors"
+            title={`${instanceInfo.software.name} v${instanceInfo.software.version}${instanceInfo.software.channel && instanceInfo.software.channel !== "local" ? ` · ${instanceInfo.software.channel}` : ""}${instanceInfo.software.build && instanceInfo.software.build !== "local" ? ` · build ${instanceInfo.software.build}` : ""}`}
           >
-            v{instanceInfo.software.version}
+            <span>v{instanceInfo.software.version}</span>
+            {instanceInfo.software.channel === "dev" && (
+              <span className="rounded bg-amber-500/20 px-1 text-[10px] font-semibold uppercase tracking-wide text-amber-600 dark:text-amber-400">
+                dev
+              </span>
+            )}
+            {instanceInfo.software.build && instanceInfo.software.build !== "local" && (
+              <span className="opacity-70">{instanceInfo.software.build}</span>
+            )}
           </SpaLink>
         </div>
       )}
@@ -471,12 +479,29 @@ export function Sidebar() {
         >
           <SpaLink
             to="/settings?tab=advanced"
-            className="text-xs text-(--text-muted) hover:text-(--text-secondary) transition-colors"
-            title={`${instanceInfo.software.name} v${instanceInfo.software.version}`}
+            className="flex items-center justify-center gap-1 text-xs text-(--text-muted) hover:text-(--text-secondary) transition-colors"
+            title={`${instanceInfo.software.name} v${instanceInfo.software.version}${instanceInfo.software.channel && instanceInfo.software.channel !== "local" ? ` · ${instanceInfo.software.channel}` : ""}${instanceInfo.software.build && instanceInfo.software.build !== "local" ? ` · build ${instanceInfo.software.build}` : ""}`}
           >
-            {isCollapsed
-              ? `v${instanceInfo.software.version.split(".")[0] || instanceInfo.software.version}`
-              : `v${instanceInfo.software.version}`}
+            {isCollapsed ? (
+              <span>
+                v{instanceInfo.software.version.split(".")[0] || instanceInfo.software.version}
+                {instanceInfo.software.channel === "dev" && (
+                  <span className="ml-0.5 text-amber-600 dark:text-amber-400">·dev</span>
+                )}
+              </span>
+            ) : (
+              <>
+                <span>v{instanceInfo.software.version}</span>
+                {instanceInfo.software.channel === "dev" && (
+                  <span className="rounded bg-amber-500/20 px-1 text-[10px] font-semibold uppercase tracking-wide text-amber-600 dark:text-amber-400">
+                    dev
+                  </span>
+                )}
+                {instanceInfo.software.build && instanceInfo.software.build !== "local" && (
+                  <span className="opacity-70">{instanceInfo.software.build}</span>
+                )}
+              </>
+            )}
           </SpaLink>
         </div>
       )}

--- a/packages/frontend/src/lib/types/instance.ts
+++ b/packages/frontend/src/lib/types/instance.ts
@@ -27,6 +27,10 @@ export interface RegistrationSettings {
 export interface SoftwareInfo {
   name: string;
   version: string;
+  /** Short git SHA of the build (e.g. "a1b2c3d"); "local" for non-CI builds. */
+  build?: string;
+  /** Source ref the build came from (e.g. "dev", "main", a tag); "local" otherwise. */
+  channel?: string;
   repository: string;
 }
 


### PR DESCRIPTION
アプリにビルド番号(git SHA)と dev 表示を追加。

- CI(build-images.yml)が ROX_BUILD_SHA(github.sha)/ ROX_BUILD_CHANNEL(github.ref_name)を build-arg で渡し、Dockerfile.backend が ENV として焼き込み(builder+production 両方)。
- /api/instance の software に build(短縮SHA)/ channel(dev/main/タグ、ローカルは local)を追加。
- Sidebar のバージョン表示に build SHA と、channel=dev のとき「dev」バッジを表示。

backend/frontend typecheck・lint パス。マージ→ :dev 再ビルドで本番(K3S, dev追従)に CronJob 経由で反映。dev ビルドでは「dev」バッジが出ます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * インスタンス情報に、ビルド識別子とリリースチャネルの表示を追加しました。
  * バージョン表示で、開発版やビルド情報をより分かりやすく確認できるようになりました。

* **バグ修正**
  * Docker ビルド時の情報が、実行時の表示に反映されるようになりました。
  * CI でのビルド引数に関する警告が出にくくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->