### PR TITLE
feat: numeric build number

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -77,3 +77,4 @@ jobs:
           build-args: |
             ROX_BUILD_SHA=${{ github.sha }}
             ROX_BUILD_CHANNEL=${{ github.ref_name }}
+            ROX_BUILD_NUMBER=${{ github.run_number }}

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -33,8 +33,10 @@ ENV NODE_ENV=production
 # runtime reads.
 ARG ROX_BUILD_SHA=local
 ARG ROX_BUILD_CHANNEL=local
+ARG ROX_BUILD_NUMBER=local
 ENV ROX_BUILD_SHA=${ROX_BUILD_SHA} \
-    ROX_BUILD_CHANNEL=${ROX_BUILD_CHANNEL}
+    ROX_BUILD_CHANNEL=${ROX_BUILD_CHANNEL} \
+    ROX_BUILD_NUMBER=${ROX_BUILD_NUMBER}
 
 # Build backend (app entrypoint). The shared package is consumed from source
 # (its package.json `main` points at src/index.ts) and bun bundles it into the
@@ -94,11 +96,13 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 # Set environment defaults
 ARG ROX_BUILD_SHA=local
 ARG ROX_BUILD_CHANNEL=local
+ARG ROX_BUILD_NUMBER=local
 ENV NODE_ENV=production \
     PORT=3000 \
     DB_TYPE=postgres \
     ROX_BUILD_SHA=${ROX_BUILD_SHA} \
-    ROX_BUILD_CHANNEL=${ROX_BUILD_CHANNEL}
+    ROX_BUILD_CHANNEL=${ROX_BUILD_CHANNEL} \
+    ROX_BUILD_NUMBER=${ROX_BUILD_NUMBER}
 
 # Run the application
 CMD ["bun", "run", "packages/backend/dist/index.js"]

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -69,6 +69,7 @@ EXPOSE 3001
 # shared CI build-args don't warn; the build identity is served by the backend.
 ARG ROX_BUILD_SHA=local
 ARG ROX_BUILD_CHANNEL=local
+ARG ROX_BUILD_NUMBER=local
 ENV NODE_ENV=production \
     FRONTEND_PORT=3001
 

--- a/packages/backend/src/routes/instance.ts
+++ b/packages/backend/src/routes/instance.ts
@@ -17,10 +17,12 @@ import rootPackageJson from "../../../../package.json";
 const ROX_VERSION = rootPackageJson.version;
 
 // Build identity, injected at image build time (see docker/Dockerfile.backend).
-// `build` is the short git SHA; `channel` is the source ref (e.g. "dev",
-// "main", a tag). Both fall back to "local" for non-CI builds.
+// `buildNumber` is the CI build counter (a human-friendly incrementing integer);
+// `build` is the short git SHA (precise reference); `channel` is the source ref
+// (e.g. "dev", "main", a tag). All fall back to "local" for non-CI builds.
 const ROX_BUILD = (process.env.ROX_BUILD_SHA || "").slice(0, 7) || "local";
 const ROX_CHANNEL = process.env.ROX_BUILD_CHANNEL || "local";
+const ROX_BUILD_NUMBER = process.env.ROX_BUILD_NUMBER || "local";
 
 const app = new Hono();
 
@@ -77,6 +79,7 @@ app.get("/", async (c: Context) => {
     software: {
       name: "rox",
       version: ROX_VERSION,
+      buildNumber: ROX_BUILD_NUMBER,
       build: ROX_BUILD,
       channel: ROX_CHANNEL,
       repository: "https://github.com/Love-rox/rox",

--- a/packages/frontend/src/components/layout/Sidebar.tsx
+++ b/packages/frontend/src/components/layout/Sidebar.tsx
@@ -293,7 +293,7 @@ export function Sidebar() {
             to="/settings?tab=advanced"
             onClick={handleNavClick}
             className="flex items-center gap-1 text-xs text-(--text-muted) hover:text-(--text-secondary) transition-colors"
-            title={`${instanceInfo.software.name} v${instanceInfo.software.version}${instanceInfo.software.channel && instanceInfo.software.channel !== "local" ? ` · ${instanceInfo.software.channel}` : ""}${instanceInfo.software.build && instanceInfo.software.build !== "local" ? ` · build ${instanceInfo.software.build}` : ""}`}
+            title={`${instanceInfo.software.name} v${instanceInfo.software.version}${instanceInfo.software.channel && instanceInfo.software.channel !== "local" ? ` · ${instanceInfo.software.channel}` : ""}${instanceInfo.software.buildNumber && instanceInfo.software.buildNumber !== "local" ? ` · build #${instanceInfo.software.buildNumber}` : ""}${instanceInfo.software.build && instanceInfo.software.build !== "local" ? ` · ${instanceInfo.software.build}` : ""}`}
           >
             <span>v{instanceInfo.software.version}</span>
             {instanceInfo.software.channel === "dev" && (
@@ -301,9 +301,11 @@ export function Sidebar() {
                 dev
               </span>
             )}
-            {instanceInfo.software.build && instanceInfo.software.build !== "local" && (
+            {instanceInfo.software.buildNumber && instanceInfo.software.buildNumber !== "local" ? (
+              <span className="opacity-70">#{instanceInfo.software.buildNumber}</span>
+            ) : instanceInfo.software.build && instanceInfo.software.build !== "local" ? (
               <span className="opacity-70">{instanceInfo.software.build}</span>
-            )}
+            ) : null}
           </SpaLink>
         </div>
       )}
@@ -480,7 +482,7 @@ export function Sidebar() {
           <SpaLink
             to="/settings?tab=advanced"
             className="flex items-center justify-center gap-1 text-xs text-(--text-muted) hover:text-(--text-secondary) transition-colors"
-            title={`${instanceInfo.software.name} v${instanceInfo.software.version}${instanceInfo.software.channel && instanceInfo.software.channel !== "local" ? ` · ${instanceInfo.software.channel}` : ""}${instanceInfo.software.build && instanceInfo.software.build !== "local" ? ` · build ${instanceInfo.software.build}` : ""}`}
+            title={`${instanceInfo.software.name} v${instanceInfo.software.version}${instanceInfo.software.channel && instanceInfo.software.channel !== "local" ? ` · ${instanceInfo.software.channel}` : ""}${instanceInfo.software.buildNumber && instanceInfo.software.buildNumber !== "local" ? ` · build #${instanceInfo.software.buildNumber}` : ""}${instanceInfo.software.build && instanceInfo.software.build !== "local" ? ` · ${instanceInfo.software.build}` : ""}`}
           >
             {isCollapsed ? (
               <span>
@@ -497,9 +499,11 @@ export function Sidebar() {
                     dev
                   </span>
                 )}
-                {instanceInfo.software.build && instanceInfo.software.build !== "local" && (
+                {instanceInfo.software.buildNumber && instanceInfo.software.buildNumber !== "local" ? (
+                  <span className="opacity-70">#{instanceInfo.software.buildNumber}</span>
+                ) : instanceInfo.software.build && instanceInfo.software.build !== "local" ? (
                   <span className="opacity-70">{instanceInfo.software.build}</span>
-                )}
+                ) : null}
               </>
             )}
           </SpaLink>

--- a/packages/frontend/src/lib/types/instance.ts
+++ b/packages/frontend/src/lib/types/instance.ts
@@ -27,6 +27,8 @@ export interface RegistrationSettings {
 export interface SoftwareInfo {
   name: string;
   version: string;
+  /** CI build counter (incrementing integer); "local" for non-CI builds. */
+  buildNumber?: string;
   /** Short git SHA of the build (e.g. "a1b2c3d"); "local" for non-CI builds. */
   build?: string;
   /** Source ref the build came from (e.g. "dev", "main", a tag); "local" otherwise. */


### PR DESCRIPTION
ビルド番号を SHA ではなく数字(CI の github.run_number=ビルド連番)で。ROX_BUILD_NUMBER を注入→/api/instance の software.buildNumber→Sidebar に #N 表示(SHA はツールチップに残置)。typecheck/lint パス。