### PR TITLE
chore: bump version to 2026.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rox",
-  "version": "2026.7.0-rc.2",
+  "version": "2026.7.0",
   "license": "AGPL-3.0-only",
   "devDependencies": {
     "@playwright/test": "^1.61.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hono_rox",
-  "version": "1.9.0-rc.2",
+  "version": "1.9.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waku_rox",
-  "version": "1.9.0-rc.2",
+  "version": "1.9.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shared",
-  "version": "1.9.0-rc.2",
+  "version": "1.9.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
## Summary
Promote 2026.7.0-rc.2 to stable **2026.7.0** (packages: 1.9.0-rc.2 → 1.9.0).

RC verification on dev is complete, including the TS 7.0.2 stable upgrade and dependency updates (#260), verified deployed and running on rox.love-rox.cc.

After merging to dev, the follow-up dev → main PR will trigger auto-tag to create `v2026.7.0` and the GitHub release.